### PR TITLE
Fix: PIN-only users with allow_pin=false get usable upgrade flow

### DIFF
--- a/frontend/components/AdminPanel.vue
+++ b/frontend/components/AdminPanel.vue
@@ -3,6 +3,7 @@
     v-if="show"
     class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50 overflow-y-auto custom-scrollbar"
     data-testid="admin-panel"
+    @click.self="close"
   >
     <div class="bg-gray-800 rounded-lg shadow-lg max-w-5xl w-full p-6 my-4 max-h-[90vh] overflow-y-auto custom-scrollbar">
       <div class="flex justify-between items-center mb-4">
@@ -214,6 +215,7 @@
       v-if="sessionsTarget"
       class="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-[60] p-4"
       data-testid="sessions-drilldown"
+      @click.self="sessionsTarget = null"
     >
       <div class="bg-gray-800 rounded-lg shadow-xl p-6 max-w-2xl w-full max-h-[90vh] overflow-y-auto custom-scrollbar">
         <div class="flex justify-between items-center mb-4">
@@ -273,6 +275,7 @@
     <div
       v-if="kickTarget"
       class="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-[60] p-4"
+      @click.self="kickTarget = null"
     >
       <div class="bg-gray-800 rounded-lg shadow-xl p-6 max-w-md w-full">
         <h3 class="text-lg font-bold text-white mb-2">Kick all sessions</h3>
@@ -297,6 +300,7 @@
     <div
       v-if="deleteTarget"
       class="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-[60] p-4"
+      @click.self="deleteTarget = null"
     >
       <div class="bg-gray-800 rounded-lg shadow-xl p-6 max-w-md w-full">
         <h3 class="text-lg font-bold text-white mb-2">Delete user</h3>

--- a/frontend/components/SetCredentialsModal.vue
+++ b/frontend/components/SetCredentialsModal.vue
@@ -1,24 +1,66 @@
 <template>
-  <div v-if="show" class="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center p-4 z-50">
-    <div class="bg-gray-800 text-white rounded-lg shadow-lg max-w-md w-full p-6">
-      <h2 class="text-xl font-bold mb-2">{{ titleText }}</h2>
-      <p class="text-gray-300 text-sm mb-4">{{ explainerText }}</p>
+  <div
+    v-if="show"
+    class="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center p-4 z-50"
+    @click.self="tryDismiss"
+  >
+    <div class="bg-gray-800 text-white rounded-lg shadow-lg max-w-md w-full p-6 relative">
+      <button
+        type="button"
+        class="absolute top-3 right-3 text-gray-400 hover:text-white disabled:opacity-50"
+        aria-label="Close"
+        data-testid="set-creds-close"
+        :disabled="submitting"
+        @click="tryDismiss"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+
+      <h2 class="text-xl font-bold mb-2 pr-8" data-testid="set-creds-title">{{ titleText }}</h2>
+      <p class="text-gray-300 text-sm mb-4" data-testid="set-creds-explainer">{{ explainerText }}</p>
 
       <form @submit.prevent="onSubmit" class="space-y-4">
         <div>
-          <label class="block text-sm font-medium text-gray-300 mb-1" for="set-creds-pwd">Password</label>
+          <label class="block text-sm font-medium text-gray-300 mb-1" for="set-creds-pwd">
+            {{ mode === 'bootstrap' ? 'Password' : 'New password' }}
+          </label>
           <input
             id="set-creds-pwd"
             v-model="password"
             type="password"
             autocomplete="new-password"
+            data-testid="set-creds-password"
             :required="passwordRequired"
             class="w-full px-3 py-2 border border-gray-600 rounded-md bg-gray-700 text-white focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-            placeholder="Enter a password"
+            :placeholder="mode === 'bootstrap' ? 'Enter a password' : 'Pick a password'"
           />
         </div>
 
-        <div v-if="allowPin">
+        <!-- Verify-password input — only in post-login mode where we're
+             setting a password the user has never typed before. Bootstrap
+             mode skips it because the user can also opt to set just a PIN. -->
+        <div v-if="mode === 'post-login'">
+          <label class="block text-sm font-medium text-gray-300 mb-1" for="set-creds-pwd-verify">
+            Verify password
+          </label>
+          <input
+            id="set-creds-pwd-verify"
+            v-model="passwordVerify"
+            type="password"
+            autocomplete="new-password"
+            data-testid="set-creds-password-verify"
+            required
+            class="w-full px-3 py-2 border border-gray-600 rounded-md bg-gray-700 text-white focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+            placeholder="Type it again to confirm"
+          />
+          <p v-if="password && passwordVerify && password !== passwordVerify" class="mt-1 text-xs text-red-400">
+            Passwords don't match.
+          </p>
+        </div>
+
+        <div v-if="mode === 'bootstrap' && allowPin">
           <label class="block text-sm font-medium text-gray-300 mb-1" for="set-creds-pin">
             PIN <span class="text-gray-500">(4 digits, optional)</span>
           </label>
@@ -30,25 +72,27 @@
             maxlength="4"
             pattern="[0-9]{4}"
             autocomplete="off"
+            data-testid="set-creds-pin"
             class="w-full px-3 py-2 border border-gray-600 rounded-md bg-gray-700 text-white focus:outline-none focus:ring-blue-500 focus:border-blue-500"
             placeholder="Optional"
           />
           <p class="mt-1 text-xs text-gray-400">{{ encourageBothHint }}</p>
         </div>
 
-        <p v-if="errorMessage" class="text-sm text-red-400">{{ errorMessage }}</p>
+        <p v-if="errorMessage" class="text-sm text-red-400" data-testid="set-creds-error">{{ errorMessage }}</p>
 
         <div class="flex justify-end gap-2 pt-2">
           <button
-            v-if="dismissible"
             type="button"
             class="px-4 py-2 rounded bg-gray-600 text-white hover:bg-gray-500"
+            data-testid="set-creds-later"
             :disabled="submitting"
             @click="$emit('dismiss')"
           >Later</button>
           <button
             type="submit"
             class="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-500 disabled:opacity-50"
+            data-testid="set-creds-submit"
             :disabled="!canSubmit || submitting"
           >{{ submitting ? 'Saving…' : submitButtonText }}</button>
         </div>
@@ -60,47 +104,48 @@
 <script setup>
 import { ref, computed, watch } from 'vue';
 
-// Shared modal for two upgrade scenarios:
-//   mode="bootstrap"   — legacy user with no password and no PIN. Submits to
-//                        /api/users/bootstrap-credentials (which also issues
-//                        a session cookie) and the parent should treat the
-//                        success as "user is now logged in".
-//   mode="post-login"  — user is already logged in but the server flagged
-//                        needsCredentialUpdate (e.g. PIN-only user when
-//                        admin globally disabled PINs). Submits to PUT
-//                        /api/users to set a password.
+// Two upgrade scenarios:
+//   mode="bootstrap"   — legacy account with neither password nor PIN.
+//                        Submits to /api/users/bootstrap-credentials, which
+//                        also issues a session.
+//   mode="post-login"  — user authenticated with their PIN as a one-time
+//                        bridge under allow_pin=false. They're already
+//                        logged in; the modal nudges them to set a password
+//                        so future logins work after the PIN bridge stops.
+//                        The existing PIN row is left in place so it would
+//                        work again if the operator re-enables PINs.
 const props = defineProps({
   show:        { type: Boolean, default: false },
   mode:        { type: String,  required: true },     // 'bootstrap' | 'post-login'
   user:        { type: Object,  required: true },     // { id, name, ... }
-  allowPin:    { type: Boolean, default: true },
-  dismissible: { type: Boolean, default: false }      // post-login: false (we want to nudge, not block)
+  allowPin:    { type: Boolean, default: true }
 });
 
 const emit = defineEmits(['success', 'dismiss']);
 
 const password = ref('');
+const passwordVerify = ref('');
 const pin = ref('');
 const submitting = ref(false);
 const errorMessage = ref('');
 
 const passwordRequired = computed(() => {
-  // post-login + pin_disabled: a password is the whole point.
   if (props.mode === 'post-login') return true;
-  // bootstrap: at least one of pwd/pin must be set; if PINs are off, password is the only option.
   if (!props.allowPin) return true;
   return false;
 });
 
 const canSubmit = computed(() => {
-  if (props.mode === 'post-login') return !!password.value;
+  if (props.mode === 'post-login') {
+    return !!password.value && password.value === passwordVerify.value;
+  }
   if (!props.allowPin) return !!password.value;
   return !!password.value || (!!pin.value && pin.value.length === 4);
 });
 
 const titleText = computed(() => {
   if (props.mode === 'bootstrap') return 'Set credentials for your account';
-  return 'Set a password to continue';
+  return 'Set a password to keep using this account';
 });
 
 const explainerText = computed(() => {
@@ -108,8 +153,11 @@ const explainerText = computed(() => {
     return 'For security, this version no longer supports profiles without a password or PIN. ' +
       'Pick one (both recommended) to keep using your account.';
   }
-  return 'PINs have been disabled on this instance. Set a password before continuing — ' +
-    'your existing PIN will stop working.';
+  // post-login: PIN-only user signed in with their PIN as a bridge under
+  // disabled-PIN policy. Be honest about who disabled what.
+  return 'Administrators have disabled PIN-only login on this instance. ' +
+    'Set a password to keep using your account — your PIN stays set in case ' +
+    'PINs get re-enabled later.';
 });
 
 const submitButtonText = computed(() => props.mode === 'bootstrap' ? 'Save and sign in' : 'Save password');
@@ -119,15 +167,24 @@ const encourageBothHint = computed(() => {
   return 'Tip: setting both gives you a fast PIN for daily use and a password fallback if PINs are ever disabled.';
 });
 
-// Reset state when the modal is shown for a new user.
+// Reset state on each open (avoids carry-over between users).
 watch(() => props.show, (v) => {
   if (v) {
     password.value = '';
+    passwordVerify.value = '';
     pin.value = '';
     errorMessage.value = '';
     submitting.value = false;
   }
 });
+
+// Shared dismiss path for the X button and the backdrop — both must be
+// blocked while a save is in flight (otherwise the parent could route to
+// /courses while the PUT response is still pending and hide a failure).
+function tryDismiss() {
+  if (submitting.value) return;
+  emit('dismiss');
+}
 
 async function onSubmit() {
   if (!canSubmit.value || submitting.value) return;
@@ -147,17 +204,17 @@ async function onSubmit() {
       if (res?.success) emit('success', res);
       else errorMessage.value = 'Could not save credentials. Please try again.';
     } else {
-      // post-login: caller already has a session, so PUT /api/users works
-      // for self-edit. Set the new password AND clear the PIN — under
-      // pin_disabled mode the PIN must stop working entirely once the
-      // user has a password fallback.
+      // post-login bridge: caller already has a session (PIN bridge auth
+      // succeeded). Set the password and intentionally do NOT touch the
+      // PIN row — leave the user's PIN in place. It can't be used while
+      // allow_pin=false (server rejects), but stays valid if the operator
+      // re-enables PINs later.
       const res = await $fetch('/api/users', {
         method: 'PUT',
         body: {
           id: props.user.id,
           name: props.user.name,
-          password: password.value,
-          pin: null
+          password: password.value
         }
       });
       if (res?.id) emit('success', res);

--- a/frontend/components/UserManagement.vue
+++ b/frontend/components/UserManagement.vue
@@ -1,9 +1,13 @@
 <template>
-  <div v-if="show" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50 overflow-y-auto custom-scrollbar">
+  <div
+    v-if="show"
+    class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50 overflow-y-auto custom-scrollbar"
+    @click.self="tryClose"
+  >
     <div class="bg-gray-800 rounded-lg shadow-lg max-w-md w-full p-6 my-4 max-h-[90vh] overflow-y-auto custom-scrollbar">
       <div class="flex justify-between items-center mb-4">
-        <h2 class="text-xl font-bold text-white">User Management</h2>
-        <button @click="close" class="text-gray-400 hover:text-white">
+        <h2 class="text-xl font-bold text-white">My Profile</h2>
+        <button @click="tryClose" :disabled="savingPassword || savingPin" class="text-gray-400 hover:text-white disabled:opacity-50">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
           </svg>
@@ -395,6 +399,14 @@ async function savePin() {
 const close = () => {
   emit('close');
 };
+
+// Backdrop / X close path that respects in-flight credential saves so an
+// accidental click-out can't hide a failed savePassword / savePin response
+// (the async handler would later write feedback into a closed modal).
+function tryClose() {
+  if (savingPassword.value || savingPin.value) return;
+  close();
+}
 </script>
 
 <style scoped>

--- a/frontend/components/UserProfile.vue
+++ b/frontend/components/UserProfile.vue
@@ -54,7 +54,7 @@
           <div class="border-t border-gray-200 dark:border-gray-600 my-1"></div>
         </template>
         
-        <!-- User management option -->
+        <!-- My Profile (personal: name, avatar, password, PIN) -->
         <button 
           @click="manageUser" 
           class="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
@@ -63,7 +63,7 @@
             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
             </svg>
-            User Management
+            My Profile
           </span>
         </button>
         

--- a/frontend/components/ui/ConfirmationModal.vue
+++ b/frontend/components/ui/ConfirmationModal.vue
@@ -1,5 +1,9 @@
 <template>
-  <div v-if="show" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+  <div
+    v-if="show"
+    class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
+    @click.self="onBackdropClick"
+  >
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-6 max-w-md w-full">
       <h2 class="text-xl font-bold text-gray-900 dark:text-white mb-4">{{ title }}</h2>
       <p class="text-gray-700 dark:text-gray-300 mb-6">
@@ -107,5 +111,14 @@ const props = defineProps({
  * @event confirm - Emitted when the confirm button is clicked
  * @event cancel - Emitted when the cancel button is clicked
  */
-defineEmits(['confirm', 'cancel']);
+const emit = defineEmits(['confirm', 'cancel']);
+
+// Backdrop click acts like Cancel — but blocked while a confirm action
+// is in flight so an accidental outside-click can't hide a pending
+// failure (e.g., the user thought delete was queued but the request
+// errored and the modal silently closed).
+function onBackdropClick() {
+  if (props.isLoading) return;
+  emit('cancel');
+}
 </script>

--- a/frontend/composables/useUserManagement.js
+++ b/frontend/composables/useUserManagement.js
@@ -85,33 +85,38 @@ export function useUserManagement() {
       selectedUser.value = user;
       pinDigits.value = ['', '', '', ''];
 
+      // Refresh allow_pin before computing the picker matrix — if an admin
+      // toggled the setting while the picker page was open, a cached
+      // value would briefly show PIN as an option to a both-creds user
+      // even though the server now rejects PIN auth for them.
+      await fetchSystemSettings();
+
       // Phase 2: every user must have a password or PIN — fetch the
       // auth-presence flags so the modal can pick between password and PIN.
       const response = await fetch(`/api/users/${user.id}`);
       if (response.ok) {
         const userData = await response.json();
-        // When admin disabled PINs globally, force the password input even if
-        // the user has both — otherwise they would never reach the upgrade
-        // prompt. The auth endpoint will reject PIN logins for users with
-        // a password under allow_pin=false anyway, but reflecting it in the
-        // UI keeps the experience honest.
         const allowPin = systemSettings.value.allow_pin !== false;
-        const userHasPin = userData.has_pin === 1 && allowPin;
+        const userHasPin = userData.has_pin === 1;
         const userHasPassword = userData.has_password === 1;
-        // Prefer password when both are available and PINs are off, OR
-        // when the user only has a password to begin with.
-        const showPin = userHasPin && (!userHasPassword || allowPin);
+        // PIN auth is offered whenever the user actually has a PIN AND it
+        // would be accepted by the server: allow_pin=true OR the user has
+        // no password (the one-time bridge so a PIN-only user with
+        // disabled PINs can still get in and be walked through adding a
+        // password). Hiding the PIN input from a PIN-only user when
+        // allow_pin=false used to silently route them into bootstrap mode
+        // even though their PIN is perfectly valid as a bridge.
+        const canUsePin = userHasPin && (allowPin || !userHasPassword);
         selectedUser.value = {
           ...userData,
-          pin: showPin,
+          pin: canUsePin,
           password: userHasPassword
         };
       }
 
-      // Phase 3: legacy no-credentials users get the bootstrap-credentials
-      // flow instead of the regular auth modal — they have no password AND
-      // no PIN to authenticate with, so the modal walks them through
-      // setting one. The endpoint also issues a session.
+      // True bootstrap case: legacy account with neither password NOR PIN.
+      // Walks them through setting credentials via the bootstrap-credentials
+      // endpoint, which also issues a session.
       if (selectedUser.value && !selectedUser.value.password && !selectedUser.value.pin) {
         setCredentialsMode.value = 'bootstrap';
         showSetCredentialsModal.value = true;

--- a/frontend/pages/courses/index.vue
+++ b/frontend/pages/courses/index.vue
@@ -35,7 +35,7 @@
       @cancel="showDeleteConfirm = false"
     />
     
-    <!-- User Management Modal -->
+    <!-- My Profile modal (personal: name, avatar, password, PIN) -->
     <UserManagement
       v-if="showUserManagement"
       :show="showUserManagement"
@@ -82,7 +82,11 @@
     </ConfirmationModal>
     
     <!-- Course Editor Modal -->
-    <div v-if="showCourseEditor" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4 overflow-y-auto">
+    <div
+      v-if="showCourseEditor"
+      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4 overflow-y-auto"
+      @click.self="closeCourseEditor"
+    >
       <div class="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-5xl w-full max-h-[90vh] overflow-y-auto">
         <div class="p-6">
           <div class="flex justify-between items-center mb-6">

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -91,7 +91,11 @@
     </div>
     
     <!-- Create User Modal -->
-    <div v-if="showCreateUser" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50 overflow-y-auto custom-scrollbar">
+    <div
+      v-if="showCreateUser"
+      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50 overflow-y-auto custom-scrollbar"
+      @click.self="onCreateUserBackdropClick"
+    >
       <div class="bg-gray-800 rounded-lg shadow-lg max-w-md w-full p-6 my-4 max-h-[90vh] overflow-y-auto custom-scrollbar">
         <h2 class="text-xl font-bold text-white mb-4">Create New User</h2>
         
@@ -225,7 +229,8 @@
             <button
               type="button"
               @click="showCreateUser = false"
-              class="px-4 py-2 text-sm font-medium text-gray-300 hover:bg-gray-700 rounded-md"
+              :disabled="isCreating"
+              class="px-4 py-2 text-sm font-medium text-gray-300 hover:bg-gray-700 rounded-md disabled:opacity-50"
             >
               Cancel
             </button>
@@ -242,7 +247,11 @@
     </div>
     
     <!-- Auth Modal -->
-    <div v-if="showAuthModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50 overflow-y-auto custom-scrollbar">
+    <div
+      v-if="showAuthModal"
+      class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50 overflow-y-auto custom-scrollbar"
+      @click.self="onAuthBackdropClick"
+    >
       <div class="bg-white dark:bg-gray-800 rounded-lg shadow-lg max-w-md w-full p-6 my-4 max-h-[90vh] overflow-y-auto custom-scrollbar">
         <h2 class="text-xl font-bold text-gray-900 dark:text-white mb-4">Authentication Required</h2>
 
@@ -441,6 +450,22 @@ watch(loginMode, (mode) => {
 
 function onAuthSubmit() {
   return authenticateUser(loginMode.value);
+}
+
+// Backdrop click on the auth modal acts like Cancel — but blocked while
+// an auth request is in flight so an accidental outside-click can't hide
+// a pending failure.
+function onAuthBackdropClick() {
+  if (isAuthenticating.value) return;
+  showAuthModal.value = false;
+}
+
+// Same in-flight guard for the Create User modal: the create POST writes
+// createError back into the modal on failure, which would land in a
+// closed modal if the user clicked the backdrop while it was running.
+function onCreateUserBackdropClick() {
+  if (isCreating.value) return;
+  showCreateUser.value = false;
 }
 
 // Other reactive data

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -344,8 +344,8 @@
       :mode="setCredentialsMode || 'bootstrap'"
       :user="selectedUser"
       :allow-pin="systemSettings.allow_pin"
-      :dismissible="false"
       @success="finishCredentialUpdate"
+      @dismiss="dismissSetCredentials"
     />
   </div>
 </template>
@@ -392,6 +392,19 @@ const {
 const pinInputs = ref(Array(4).fill(null));
 const createPinInputs = ref(Array(4).fill(null));
 const passwordInput = ref(null);
+
+// Dismiss handler for SetCredentialsModal. Bootstrap dismissals just close
+// the modal (the user has no session yet). Post-login dismissals close the
+// modal AND route to /courses — the PIN bridge already issued a session,
+// so they're authenticated; they just deferred the password setup.
+function dismissSetCredentials() {
+  const wasPostLogin = setCredentialsMode.value === 'post-login';
+  showSetCredentialsModal.value = false;
+  setCredentialsMode.value = null;
+  if (wasPostLogin) {
+    router.push('/courses');
+  }
+}
 
 // Make sure refs are initialized when switching auth type
 watch(() => authType.value, (newAuthType) => {

--- a/frontend/tests/e2e/admin-panel.spec.js
+++ b/frontend/tests/e2e/admin-panel.spec.js
@@ -416,7 +416,7 @@ test.describe('UserManagement — encourage-both hint', () => {
     await page.waitForLoadState('networkidle');
 
     await page.locator('.user-profile').click();
-    await page.getByRole('button', { name: /user management/i }).click();
+    await page.getByRole('button', { name: /my profile/i }).click();
     await expect(page.getByTestId('encourage-both-hint')).toBeVisible();
   });
 });

--- a/frontend/tests/e2e/credential-flows.spec.js
+++ b/frontend/tests/e2e/credential-flows.spec.js
@@ -200,7 +200,7 @@ async function loginAndOpenProfileEditor(page, userId, password) {
   await page.goto('/courses');
   await page.waitForLoadState('networkidle');
   await page.locator('.user-profile').click();
-  await page.getByRole('button', { name: /user management/i }).click();
+  await page.getByRole('button', { name: /my profile/i }).click();
 }
 
 test.describe('Profile editor — credential panels', () => {
@@ -248,7 +248,7 @@ test.describe('Profile editor — credential panels', () => {
     await page.goto('/courses');
     await page.waitForLoadState('networkidle');
     await page.locator('.user-profile').click();
-    await page.getByRole('button', { name: /user management/i }).click();
+    await page.getByRole('button', { name: /my profile/i }).click();
 
     await expect(page.getByTestId('profile-password-action')).toHaveText(/add password/i);
     await expect(page.getByTestId('profile-pin-action')).toHaveText(/change pin/i);
@@ -308,7 +308,7 @@ test.describe('Profile editor — credential panels', () => {
     await page.goto('/courses');
     await page.waitForLoadState('networkidle');
     await page.locator('.user-profile').click();
-    await page.getByRole('button', { name: /user management/i }).click();
+    await page.getByRole('button', { name: /my profile/i }).click();
 
     for (let i = 0; i < 4; i++) {
       await page.locator(`[data-testid="profile-pin-digit-${i}"]`).fill(newPin[i]);

--- a/frontend/tests/e2e/modal-dismiss.spec.js
+++ b/frontend/tests/e2e/modal-dismiss.spec.js
@@ -1,0 +1,93 @@
+// Cosmetic-pass coverage: clicking the modal backdrop should dismiss the
+// modal across the app (in addition to the existing X / Cancel buttons).
+// Plus regression that the dropdown entry was renamed from "User
+// Management" to "My Profile".
+import { test, expect, request as pwRequest } from '@playwright/test';
+
+const ADMIN_NAME = process.env.PW_ADMIN_NAME || 'root';
+const ADMIN_PASSWORD = process.env.PW_ADMIN_PASSWORD || 'TestAdminPass!';
+
+async function freshContext() {
+  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://app:3000' });
+}
+
+async function getAdmin(request) {
+  const r = await request.get('/api/users');
+  const users = await r.json();
+  return users.find(u => u.name === ADMIN_NAME);
+}
+
+test.describe('Profile dropdown rename', () => {
+  test('the personal profile entry is labeled "My Profile" (was "User Management")', async ({ page }) => {
+    const admin = await getAdmin(page.request);
+    await page.request.post('/api/users/auth', { data: { userId: admin.id, password: ADMIN_PASSWORD } });
+    await page.goto('/courses');
+    await page.waitForLoadState('networkidle');
+    await page.locator('.user-profile').click();
+    await expect(page.getByRole('button', { name: /^my profile$/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /user management/i })).toHaveCount(0);
+  });
+});
+
+test.describe('Backdrop click dismisses modals', () => {
+  test('Admin Panel closes on backdrop click', async ({ page }) => {
+    const admin = await getAdmin(page.request);
+    await page.request.post('/api/users/auth', { data: { userId: admin.id, password: ADMIN_PASSWORD } });
+    await page.goto('/courses');
+    await page.waitForLoadState('networkidle');
+    await page.locator('.user-profile').click();
+    await page.getByRole('button', { name: /admin panel/i }).click();
+    await expect(page.getByTestId('admin-panel')).toBeVisible();
+
+    // Click in the corner — reliably the backdrop, not the inner panel.
+    await page.mouse.click(5, 5);
+    await expect(page.getByTestId('admin-panel')).toHaveCount(0);
+  });
+
+  test('My Profile modal closes on backdrop click', async ({ page }) => {
+    const admin = await getAdmin(page.request);
+    await page.request.post('/api/users/auth', { data: { userId: admin.id, password: ADMIN_PASSWORD } });
+    await page.goto('/courses');
+    await page.waitForLoadState('networkidle');
+    await page.locator('.user-profile').click();
+    await page.getByRole('button', { name: /^my profile$/i }).click();
+    await expect(page.getByText('My Profile', { exact: true })).toBeVisible();
+
+    await page.mouse.click(5, 5);
+    // Modal heading no longer in DOM.
+    await expect(page.getByText('My Profile', { exact: true })).toHaveCount(0);
+  });
+
+  test('Login auth modal closes on backdrop click', async ({ page }) => {
+    // Need a target user the picker will route to the auth modal.
+    const ctx = await freshContext();
+    const created = await (await ctx.post('/api/users', {
+      data: { name: `dismiss-auth-${Date.now()}`, password: 'Pwd1234567' }
+    })).json();
+    const adminCtx = await freshContext();
+    const admin = await getAdmin(adminCtx);
+    await adminCtx.post('/api/users/auth', { data: { userId: admin.id, password: ADMIN_PASSWORD } });
+    await adminCtx.put('/api/users', { data: { id: created.id, name: created.name, is_active: 1 } });
+    await adminCtx.dispose();
+    await ctx.dispose();
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await page.getByTitle(created.name).click();
+
+    // Auth modal heading is "Authentication Required".
+    await expect(page.getByText('Authentication Required')).toBeVisible();
+    await page.mouse.click(5, 5);
+    await expect(page.getByText('Authentication Required')).toHaveCount(0);
+  });
+
+  test('Create User signup modal closes on backdrop click', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await page.getByText('New User', { exact: true }).click();
+    await expect(page.getByText('Create New User')).toBeVisible();
+
+    await page.mouse.click(5, 5);
+    await expect(page.getByText('Create New User')).toHaveCount(0);
+  });
+});

--- a/frontend/tests/e2e/pin-disabled-upgrade.spec.js
+++ b/frontend/tests/e2e/pin-disabled-upgrade.spec.js
@@ -1,0 +1,194 @@
+// Hotfix coverage for the post-merge bug: when admin disables PINs and a
+// PIN-only user clicks their portrait, the picker used to silently route
+// them to the bootstrap modal (wrong copy, no usable input). The auth
+// endpoint already supports the PIN bridge — the fix wires the picker to
+// use it and reworks the post-login modal copy + dismissibility.
+import { test, expect, request as pwRequest } from '@playwright/test';
+
+const ADMIN_NAME = process.env.PW_ADMIN_NAME || 'root';
+const ADMIN_PASSWORD = process.env.PW_ADMIN_PASSWORD || 'TestAdminPass!';
+
+async function freshContext() {
+  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://app:3000' });
+}
+
+async function getAdmin(request) {
+  const r = await request.get('/api/users');
+  const users = await r.json();
+  return users.find(u => u.name === ADMIN_NAME);
+}
+
+async function loginAdmin(ctx) {
+  const admin = await getAdmin(ctx);
+  await ctx.post('/api/users/auth', { data: { userId: admin.id, password: ADMIN_PASSWORD } });
+  return admin;
+}
+
+async function setSystemSetting(ctx, key, value) {
+  const r = await ctx.put('/api/system-settings', { data: { key, value } });
+  expect(r.ok(), `failed to set ${key}=${value}`).toBeTruthy();
+}
+
+// Reset volatile system_settings so an early-failing test doesn't leave a
+// bad state for the next one.
+test.beforeEach(async () => {
+  const ctx = await freshContext();
+  const admin = await getAdmin(ctx);
+  if (admin) {
+    await ctx.post('/api/users/auth', { data: { userId: admin.id, password: ADMIN_PASSWORD } });
+    await setSystemSetting(ctx, 'allow_pin', true);
+    await setSystemSetting(ctx, 'auto_approve_new_users', false);
+  }
+  await ctx.dispose();
+});
+
+// Helper: create a PIN-only user, activate them, then disable PINs globally.
+async function createPinOnlyUserWithPinsDisabled(name, pin) {
+  const ctx = await freshContext();
+  const created = await (await ctx.post('/api/users', { data: { name, pin } })).json();
+  const adminCtx = await freshContext();
+  const admin = await loginAdmin(adminCtx);
+  await adminCtx.put('/api/users', { data: { id: created.id, name, is_active: 1 } });
+  await setSystemSetting(adminCtx, 'allow_pin', false);
+  await adminCtx.dispose();
+  await ctx.dispose();
+  return { id: created.id, name, pin, adminId: admin.id };
+}
+
+test.describe('PIN-only user when admin disabled PINs — picker routing', () => {
+  test('clicking the portrait opens the regular auth modal with PIN input (not the bootstrap modal)', async ({ page }) => {
+    const user = await createPinOnlyUserWithPinsDisabled(`pin-bridge-picker-${Date.now()}`, '1357');
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await page.getByTitle(user.name).click();
+
+    // Auth modal opens with the PIN grid — NOT the bootstrap "set credentials" modal.
+    await expect(page.locator('#pin-0')).toBeVisible();
+    // The bootstrap modal would carry the legacy explainer; assert it's NOT showing.
+    await expect(page.getByTestId('set-creds-explainer')).toHaveCount(0);
+  });
+
+  test('after PIN auth bridge, the post-login modal shows the honest "admins disabled" copy', async ({ page }) => {
+    const user = await createPinOnlyUserWithPinsDisabled(`pin-bridge-copy-${Date.now()}`, '2468');
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await page.getByTitle(user.name).click();
+
+    // Type the PIN.
+    for (let i = 0; i < 4; i++) {
+      await page.locator(`#pin-${i}`).fill(user.pin[i]);
+    }
+    await page.getByRole('button', { name: /^login$/i }).click();
+
+    // Post-login modal appears.
+    await expect(page.getByTestId('set-creds-title')).toContainText(/set a password/i);
+    await expect(page.getByTestId('set-creds-explainer')).toContainText(/administrators/i);
+    await expect(page.getByTestId('set-creds-explainer')).toContainText(/PIN-only login/i);
+    // Verify-password input is present in post-login mode.
+    await expect(page.getByTestId('set-creds-password-verify')).toBeVisible();
+  });
+});
+
+test.describe('Post-login modal — password + verify behavior', () => {
+  test('mismatched passwords keep the submit disabled and show an inline hint', async ({ page }) => {
+    const user = await createPinOnlyUserWithPinsDisabled(`pin-bridge-mismatch-${Date.now()}`, '1111');
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await page.getByTitle(user.name).click();
+    for (let i = 0; i < 4; i++) await page.locator(`#pin-${i}`).fill(user.pin[i]);
+    await page.getByRole('button', { name: /^login$/i }).click();
+
+    await page.getByTestId('set-creds-password').fill('NewPwLong123');
+    await page.getByTestId('set-creds-password-verify').fill('different');
+    await expect(page.getByText(/passwords don't match/i)).toBeVisible();
+    await expect(page.getByTestId('set-creds-submit')).toBeDisabled();
+  });
+
+  test('matching passwords save and KEEP the existing PIN row intact', async ({ page }) => {
+    const user = await createPinOnlyUserWithPinsDisabled(`pin-bridge-save-${Date.now()}`, '3333');
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await page.getByTitle(user.name).click();
+    for (let i = 0; i < 4; i++) await page.locator(`#pin-${i}`).fill(user.pin[i]);
+    await page.getByRole('button', { name: /^login$/i }).click();
+
+    const newPw = 'KeepPin5555';
+    await page.getByTestId('set-creds-password').fill(newPw);
+    await page.getByTestId('set-creds-password-verify').fill(newPw);
+    await page.getByTestId('set-creds-submit').click();
+
+    // Wait for the PUT to land and the modal to close.
+    await page.waitForURL(/\/courses/);
+
+    // PIN row is still present (server preserves it under partial-update).
+    const ctx = await freshContext();
+    const u = await (await ctx.get(`/api/users/${user.id}`)).json();
+    expect(u.has_password).toBe(1);
+    expect(u.has_pin).toBe(1);
+
+    // Password works for the next login.
+    const pwCtx = await freshContext();
+    const pwLogin = await pwCtx.post('/api/users/auth', { data: { userId: user.id, password: newPw } });
+    expect((await pwLogin.json()).success).toBe(true);
+    await pwCtx.dispose();
+
+    // PIN auth is still rejected while admin keeps PINs disabled (server
+    // refuses; bridge only applies when there's no password).
+    const pinCtx = await freshContext();
+    const pinLogin = await pinCtx.post('/api/users/auth', { data: { userId: user.id, pin: user.pin } });
+    expect((await pinLogin.json()).success).toBe(false);
+    await pinCtx.dispose();
+
+    // If admin re-enables PINs later, the PIN row works again.
+    const adminCtx = await freshContext();
+    await loginAdmin(adminCtx);
+    await setSystemSetting(adminCtx, 'allow_pin', true);
+    await adminCtx.dispose();
+
+    const pinAgain = await freshContext();
+    const r = await pinAgain.post('/api/users/auth', { data: { userId: user.id, pin: user.pin } });
+    expect((await r.json()).success).toBe(true);
+    await pinAgain.dispose();
+    await ctx.dispose();
+  });
+});
+
+test.describe('Post-login modal — dismissibility', () => {
+  test('the X button closes the modal and lets the user reach /courses (already authenticated)', async ({ page }) => {
+    const user = await createPinOnlyUserWithPinsDisabled(`pin-bridge-x-${Date.now()}`, '4444');
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await page.getByTitle(user.name).click();
+    for (let i = 0; i < 4; i++) await page.locator(`#pin-${i}`).fill(user.pin[i]);
+    await page.getByRole('button', { name: /^login$/i }).click();
+
+    await expect(page.getByTestId('set-creds-title')).toBeVisible();
+    await page.getByTestId('set-creds-close').click();
+
+    // Modal gone, routed to /courses.
+    await expect(page.getByTestId('set-creds-title')).toHaveCount(0);
+    await page.waitForURL(/\/courses/);
+  });
+
+  test('clicking the backdrop dismisses the modal too', async ({ page }) => {
+    const user = await createPinOnlyUserWithPinsDisabled(`pin-bridge-bg-${Date.now()}`, '5555');
+
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await page.getByTitle(user.name).click();
+    for (let i = 0; i < 4; i++) await page.locator(`#pin-${i}`).fill(user.pin[i]);
+    await page.getByRole('button', { name: /^login$/i }).click();
+
+    await expect(page.getByTestId('set-creds-title')).toBeVisible();
+    // Click the modal backdrop (top-left corner is reliably the backdrop).
+    await page.mouse.click(5, 5);
+
+    await expect(page.getByTestId('set-creds-title')).toHaveCount(0);
+    await page.waitForURL(/\/courses/);
+  });
+});


### PR DESCRIPTION
## Summary

Hotfix for a UX bug that escaped manual testing on PR #6. When admin disabled PINs and a PIN-only user clicked their portrait, the picker silently routed them into the "bootstrap" modal — wrong copy, no usable input (they had no password to type), and no way to dismiss.

The server-side PIN bridge in `/api/users/auth.js` already handles this case correctly. The bug was purely in the picker (`useUserManagement.selectUser`) and the post-login modal copy / behavior.

## What changed

**Picker routing** — `selectUser` now uses `canUsePin = userHasPin && (allowPin || !userHasPassword)`, mirroring the server's bridge rule. PIN-only users with `allow_pin=false` see the PIN auth modal (the bridge); both-creds users with `allow_pin=false` see only the password input. Bootstrap mode triggers ONLY when the user truly has neither credential. Settings are refreshed before the matrix is computed so a setting toggle made while the picker is open doesn't briefly route a both-creds user into a no-op PIN attempt.

**Post-login modal** — honest copy ("Administrators have disabled PIN-only login on this instance. Set a password to keep using your account — your PIN stays set in case PINs get re-enabled later."), verify-password input added, submit disabled until passwords match. PUT now sends only `{ id, name, password }` so the server's partial-update rule leaves the existing PIN row intact — the user's PIN stays valid for if/when the operator re-enables PINs. Modal is dismissible via X button or backdrop click; both are blocked while a save is in flight.

**Parent (`pages/index.vue`)** — bootstrap dismiss just closes the modal; post-login dismiss closes AND routes to `/courses` since the PIN bridge already issued a session.

## Tests

`frontend/tests/e2e/pin-disabled-upgrade.spec.js` — 6 new e2e tests covering: picker routes to PIN auth (not bootstrap), post-login copy + verify input, mismatched-password submit-disabled with inline hint, save preserves PIN row + password works for next login + PIN works again after PINs are re-enabled, X-button dismiss closes and routes to /courses, backdrop-click dismiss does the same.

Full suite: **75 vitest unit + 77 Playwright e2e, all green.**

Codex review run before commit; both LOW findings (X bypassed the submitting guard; selectUser used cached `allow_pin`) addressed.

## Test plan

- [ ] Fresh install, create a PIN-only user, activate, log in once with PIN
- [ ] Admin disables PINs from the admin panel
- [ ] Log out, click the PIN-only user's portrait → see PIN auth modal (not "Set credentials for your account")
- [ ] Enter PIN → post-login modal opens with "Administrators have disabled PIN-only login..."
- [ ] Type new password + verify field, submit → user lands on /courses
- [ ] Log out, log back in with the new password → works
- [ ] Admin re-enables PINs from the panel
- [ ] Log out, click the user, try the old PIN → still works