### PR TITLE
docs: refresh handover.md for the next round

### DIFF
--- a/notes/handover.md
+++ b/notes/handover.md
@@ -1,105 +1,149 @@
-# Handover — auth-hardening branch
+# Handover — picking up after auth-hardening
 
-**Branch:** `feat/auth-hardening` (worktree: `E:/skillgoblin/.claude/worktrees/wizardly-cohen-224f57`)
-**Status:** Phases 0–3 done and tested. Phases 4–5 are open.
-**Repo:** [VladoPortos/skillgoblin](https://github.com/VladoPortos/skillgoblin)
+You are starting a fresh session. The auth-hardening + UX-polish round is fully shipped on `main` (PRs [#6](https://github.com/VladoPortos/skillgoblin/pull/6) + [#7](https://github.com/VladoPortos/skillgoblin/pull/7) merged). This doc is the cold-start brief for the **next** round of work.
 
-This doc is the cold-start brief for whoever picks the branch up next. Read it once, then `notes/process.md` for workflow rules and `notes/feature-wishlist.md` for the locked design decisions.
+The user already has a list of remaining categories. Their first message will tell you which one they picked. Until then: don't assume — read this doc, glance at the code references it points to, and wait for direction.
 
 ---
 
-## Branch state
+## TL;DR
 
-```
-66f1223 Phase 3: upgrade flows, system-settings endpoint, allow_pin enforcement
-4299278 Phase 2: cookie sessions, server-side authz, rate limiting, last-admin protection
-fae35ab Phase 1: argon2id credentials, auth-hardening migration, first-run admin bootstrap
-ac8c757 Phase 0: migration framework + test infrastructure + dead-code cleanup
-9f9bb5e readme update     ← main starts here
-```
-
-**Tests:** 34 e2e + ~75 vitest unit tests, all green in the dockerized stack.
-**PR:** Not opened yet. The plan was one consolidated PR at the end of all phases.
+- **Repo:** SkillGoblin — self-hosted homelab learning platform. Nuxt 3 + Nitro + better-sqlite3 SQLite. Designed for trusted local networks.
+- **State of `main`:** auth + admin panel + credential UX all shipped. Tests are 75 vitest unit + 82 Playwright e2e, all green in Docker.
+- **What's open:** customization (operator branding), course content polish (course.json, SRT→VTT, per-lesson README), UI polish (icons, avatar live preview), plus a list of small deferred-quality items.
+- **The user's first message after /clear** will pick a slice. Don't pre-empt it.
 
 ---
 
-## What's done — Phases 0–3 in one paragraph each
+## Hard rules (don't violate without asking)
 
-**Phase 0 — foundations.** Migration framework with `migrations` bookkeeping table and a numbered manifest at `frontend/server/migrations/`. Vitest + Playwright wired up, all run inside `docker-compose.test.yml`. Dropped 4 dead/broken endpoints that were already on main (progress.js, favorites.js, users/[id].delete.js, placeholder PUT/DELETE branches in users/[id].js). [`notes/architecture-map.md`](architecture-map.md) §10 lists what was removed and why.
-
-**Phase 1 — credentials + bootstrap.** Argon2id wrapper at `frontend/server/utils/credentials.js` with inline-on-read rehash for legacy plaintext rows. Migration `002_auth_hardening` drops `use_auth`, adds `is_active`, creates `user_sessions` and `system_settings` tables, seeds `auto_approve_new_users=false` and `allow_pin=true`. Nitro server plugin `frontend/server/plugins/bootstrap.js` refuses to start on a fresh install if `ADMIN_NAME`/`ADMIN_PASSWORD` env are missing.
-
-**Phase 2 — sessions + authz.** Opaque base64url session tokens with sha256 storage in `user_sessions`. Server middleware `frontend/server/middleware/session.js` populates `event.context.user` per request (skips `/api/content/...` and static assets for perf). `requireAuth` / `requireAdmin` / `requireSelfOrAdmin` helpers retrofit onto every mutating endpoint. In-memory rate limiter on `/api/users/auth` with exponential backoff. Last-admin-protected invariant in `lastAdminGuard.js` — refuses demote, deactivate, or delete that would leave zero active admins. Frontend rewired: `useSession` is cookie-based, `useTheme` and `useUserManagement` updated, dead `x-user-id` header dropped from courses/edit.
-
-**Phase 3 — upgrade flows + UX.** New `system-settings` endpoint (GET public for the signup screen, PUT admin-only). New `bootstrap-credentials` endpoint for legacy no-creds users — sets credentials in place and issues a session. Auth response now includes `needsCredentialUpdate: 'pin_disabled' | null`. PIN authentication is rejected when admin set `allow_pin=false`, except as a one-time bridge for users with no password. Shared `SetCredentialsModal` Vue component handles both pre-login bootstrap and post-login upgrade. Profile editor (`UserManagement.vue`) cleaned up — dead `use_auth` references gone, "Remove auth" tab removed because auth is mandatory. Server-side credential floor on PUT — refuses any update that would leave a row with neither password nor PIN.
-
----
-
-## What's left — Phases 4–5
-
-### Phase 4 — admin panel UI
-
-Backend authz exists. The admin UI to use it does not. Specifically the `/courses` page's existing admin dropdown opens `UserManagement.vue` which today only edits the *current* user. We need:
-
-- A real users-list view for admins: show all users (name, role, active state, has_password / has_pin, created_at), with per-row actions:
-  - Activate / deactivate (calls `PUT /api/users` with `is_active` — admin-only, last-admin-protected on the deactivate side)
-  - Promote / demote (PUT with `isAdmin` — admin-only, last-admin-protected on the demote side)
-  - Reset credentials (PUT with `password`/`pin` set by admin)
-  - Kick all sessions (no endpoint yet; add one — `POST /api/users/[id]/kick-sessions` or pass `kickAllSessions: true` to PUT — that calls `deleteUserSessions(db, id)` from `frontend/server/utils/sessions.js`)
-  - Delete (POST `/api/users/delete` already supports admin-deleting-other; respects last-admin protection)
-- A system-settings panel (toggle `allow_pin` and `auto_approve_new_users`) — the `PUT /api/system-settings` endpoint exists; just needs a UI.
-- An "active sessions" view (per-user `user_agent`, `last_seen_at`, `created_at`) — read directly from `user_sessions`. Endpoint to add: `GET /api/users/[id]/sessions`.
-- A "pending users" tab (filter by `is_active=0`) — relevant when `auto_approve_new_users=false` (the default). Reuses the activate row action.
-
-Tests: e2e for each admin action. Unit tests for any new endpoints.
-
-Likely commit name: `Phase 4: admin panel`.
-
-### Phase 5 — README + docs + small cleanup
-
-- Update top-level `README.md`: new env vars (`ADMIN_NAME`, `ADMIN_PASSWORD`), the first-run-admin requirement (fail-fast), the migration story for upgraders, the security model (homelab-only, X-Forwarded-* trust assumes a real reverse proxy).
-- Inline doc cleanup: any TODO/comment that points at a phase that's now done.
-- Optional: a `docker-compose.example.yml` showing the recommended setup with env vars.
-
-Likely commit name: `Phase 5: README and docs`.
-
-### Then: open the PR
-
-Per the user's preference, **one consolidated PR at the end** (not per-phase). Use `gh pr create` from this branch into `main`. PR description should reference the four phase commits and link `notes/feature-wishlist.md` + `notes/architecture-map.md`.
-
----
-
-## How to work on this branch
-
-### Workflow rules
-
-`notes/process.md` is the source of truth. Quick recap:
-
-- **Never commit to `main` directly.** All work on `feat/auth-hardening`.
-- **Migrations are forward-only and numbered.** New schema change → add `frontend/server/migrations/003_<name>.js` and append to `index.js`.
-- **Tests run in Docker, always.** `docker compose -f docker-compose.test.yml run --rm tests`. Build the app image with `--build` if you touched `Dockerfile.prod` or the lockfile.
+- **No Claude attribution in commits.** No `Co-Authored-By: Claude …` trailer, no `🤖 Generated with [Claude Code]`. The user's memory has this as a hard preference. Build commit messages that end at the explanation.
+- **Tests run in Docker only.** The host's Node + better-sqlite3 native build is broken on this Windows machine. Use:
+  ```bash
+  docker compose -f docker-compose.test.yml down -v
+  docker compose -f docker-compose.test.yml run --rm --build tests
+  ```
+  First build pulls the Playwright image (~1.5 GB, one-time) and the app image. Subsequent runs ~30 sec.
+- **Migrations are forward-only and numbered.** New schema change → add `frontend/server/migrations/003_<name>.js` and append to the `index.js` manifest.
 - **Codex review per phase before commit.** Working invocation:
   ```bash
-  node "C:/Users/vlado/.claude/plugins/cache/openai-codex/codex/1.0.2/scripts/codex-companion.mjs" task < /tmp/<phase>-prompt.md
+  node "C:/Users/vlado/.claude/plugins/cache/openai-codex/codex/1.0.2/scripts/codex-companion.mjs" task < notes/<round>-codex-prompt.md
   ```
-  The Skill / `/codex:rescue` slash-command path hangs in this environment — see [`feedback_codex.md`](../../C:/Users/vlado/.claude/projects/E--skillgoblin/memory/feedback_codex.md) in the user's memory.
+  The Skill / `/codex:rescue` slash-command path hangs in this environment — Bash invocation is the only one that works. (The user's memory captures this too.)
+- **TDD discipline.** Failing test before code, watch it fail, then GREEN. Existing test layout: `frontend/tests/unit/` (vitest, against in-memory SQLite) and `frontend/tests/e2e/` (Playwright against the dockerized app).
 
-### Running tests (the only verification path)
+---
 
-```bash
-cd E:/skillgoblin/.claude/worktrees/wizardly-cohen-224f57
-docker compose -f docker-compose.test.yml down -v
-docker compose -f docker-compose.test.yml run --rm --build tests
-```
+## What shipped (don't re-do this work)
 
-The first build pulls the Playwright image (~1.5 GB, one-time) and builds the app image. Subsequent runs are ~30 sec.
+Across PRs #6 and #7:
 
-The compose file sets `ADMIN_NAME=root` / `ADMIN_PASSWORD=TestAdminPass!` for the app service so the bootstrap plugin can satisfy its fail-fast requirement. Don't change those without also updating `tests/e2e/auth.spec.js` and `tests/e2e/sessions.spec.js`.
+- **argon2id credentials** with inline rehash for legacy plaintext rows ([credentials.js](frontend/server/utils/credentials.js))
+- **Cookie sessions** stored in `user_sessions` (sha256, 30-day sliding) with admin "kick all" and per-user revoke ([sessions.js](frontend/server/utils/sessions.js), [middleware/session.js](frontend/server/middleware/session.js))
+- **`requireAuth` / `requireAdmin` / `requireSelfOrAdmin`** on every mutating endpoint ([authz.js](frontend/server/utils/authz.js))
+- **First-run admin bootstrap** from `ADMIN_NAME` / `ADMIN_PASSWORD` env vars; refuses to start otherwise ([bootstrap.js](frontend/server/utils/bootstrap.js))
+- **Multi-admin with last-admin protection** ([lastAdminGuard.js](frontend/server/utils/lastAdminGuard.js))
+- **In-memory rate limiter** on `/api/users/auth` ([rate-limit.js](frontend/server/utils/rate-limit.js))
+- **Forward-only migration framework** with a `migrations` bookkeeping table ([migrations.js](frontend/server/utils/migrations.js))
+- **Admin Panel UI** — users list with activate/promote/reset/kick/delete, sessions drilldown, pending-only filter, system settings tab ([AdminPanel.vue](frontend/components/AdminPanel.vue))
+- **Login modes:** password / PIN / both. Login modal toggle when user has both. PIN bridge for the pin_disabled upgrade flow.
+- **My Profile editor** — independent password and PIN panels, each saves on its own button with inline ✓/✗ feedback ([UserManagement.vue](frontend/components/UserManagement.vue) — file kept its old name; user-facing label is "My Profile")
+- **Backdrop dismiss** on every modal in the app, with in-flight save guards
+- **Runtime-toggleable system settings** (`allow_pin`, `auto_approve_new_users`) via `/api/system-settings` ([system-settings/index.js](frontend/server/api/system-settings/index.js))
+- **README rewrite** with the new auth model, env vars, security caveats, upgrade story
+- **`docker-compose.example.yml`** with placeholder admin credentials for first install
 
-### Lockfile changes
+---
 
-Bumping a dep needs the lockfile regenerated *inside Docker* (the host's Node 24 + better-sqlite3 native build is broken on this Windows machine):
+## What's left — the user will pick
 
+### A. Customization / branding
+
+Operator-configurable so a homelab user can re-skin their instance. None of these built yet.
+- App name + short name configurable via env (window title, web manifest, header)
+- App description configurable
+- Theme color / background color configurable
+- Custom logo: drop `logo.png` in a documented location, served via `/api/logo`, falls back to bundled defaults
+- Web manifest generated dynamically so the PWA install reflects operator branding
+
+These cluster well as one round (same shape: env config → exposed via small endpoint → consumed by frontend templates).
+
+### B. Course content polish
+
+Independent of auth. Better default UX for course libraries.
+- **`course.json` metadata override** — drop a JSON in a course folder to set `title` / `description` / `category` / `releaseDate`. Folder-derived defaults still work without it.
+- **SRT → VTT auto-conversion** so user-supplied subtitles play in `<video>` directly. Detect language from filename suffixes (`name.en.srt`, `name_es.srt`).
+- **Captions vs subtitles distinction** when filenames hint (`*_cc.*`).
+- **Per-lesson README** rendered alongside the video player.
+
+### C. UI polish
+
+Small ergonomic items.
+- Missing icons in the user dropdown menu (some entries text-only)
+- Avatar live preview while editing profile
+
+### D. Deferred quality items
+
+Captured in commit bodies. Not blockers — defer-list candidates if/when convenient.
+
+| Item | Where | Why deferred |
+|---|---|---|
+| `X-Forwarded-Proto` / `X-Forwarded-For` trusted unconditionally | [middleware/session.js](frontend/server/middleware/session.js), [api/users/auth.js](frontend/server/api/users/auth.js) | Acceptable behind a real reverse proxy — the documented deployment model |
+| `touchSession` doesn't check `changes` count | [utils/sessions.js](frontend/server/utils/sessions.js) | Race with logout briefly re-issues a cookie for a deleted row; next request clears it |
+| `/api/users/[id]` GET leaks `isAdmin`, `is_active`, `has_password`, `has_pin` | [api/users/[id].js](frontend/server/api/users/[id].js) | Login picker needs these |
+| Migration runner uses raw `BEGIN` | [utils/migrations.js](frontend/server/utils/migrations.js) | No nested transactions yet; swap to `db.transaction()` when one needs to nest |
+| `001_initial` thumbnail_data column ordering differs between fresh and upgraded | [migrations/001_initial.js](frontend/server/migrations/001_initial.js) | Harmless for named queries; only matters if `SELECT *` is ever used |
+| Bootstrap-credentials success-path e2e gap | [tests/e2e/upgrade-flows.spec.js](frontend/tests/e2e/upgrade-flows.spec.js) | Would need a fixture inserting a legacy no-creds row; failure cases are covered |
+| Rate limiter is per-process | [utils/rate-limit.js](frontend/server/utils/rate-limit.js) | Cluster mode isn't used; documented in the file |
+
+### Out of scope
+
+Not on the wishlist; only revisit if the user asks:
+- Multi-tenant / multi-org auth
+- OAuth / SSO
+- 2FA
+- Public-internet-grade hardening (WAF, paranoid rate-limits)
+
+---
+
+## How to start the next round
+
+1. **Read [notes/feature-wishlist.md](feature-wishlist.md)** — the locked design doc. Captures *what* and *why*. Anything in there is decided; don't relitigate.
+2. **Read [notes/architecture-map.md](architecture-map.md)** — implementation map. Where things live, how layers connect.
+3. **Read [notes/process.md](process.md)** — workflow rules. Phases, commits, atomic units.
+4. **Confirm green starting state**:
+   ```bash
+   docker compose -f docker-compose.test.yml run --rm --build tests
+   ```
+   Should print `75 passed (vitest)` + `82 passed (e2e)`. If not — investigate before doing anything else.
+5. **Wait for the user's first message** to pick the slice (A/B/C/D from above). Don't assume.
+6. **Once they pick, propose a brief plan** (2–4 bullets, the design decisions, locked in by their go-ahead) before touching code. Same pattern as the auth phases.
+7. **TDD per slice.** Write the failing test, watch it fail, implement minimum, watch it pass, refactor.
+8. **Codex review before commit.** Write a `notes/<round>-codex-prompt.md` describing the change, severity gating, and what to focus on. Run via the Bash invocation above. Address BLOCKER + HIGH + reasonable MEDIUMs; document LOW deferrals in commit body.
+9. **Commit per phase, push, open PR.** Keep PR scoped to one category — don't mix customization with course-pipeline work in the same PR.
+
+---
+
+## Local environment
+
+### Manual-test stack
+
+There's a `docker-compose.manual.yml` (untracked, not in main — it lives only in worktree filesystem) that runs a fresh-install instance for visual testing:
+- URL: `http://localhost:3001`
+- Admin: `admin` / `ChangeMe2026!`
+- Sandbox: `manual-test/data/{database,content}/` so it never touches the real `./data/`
+- Stop: `docker compose -f docker-compose.manual.yml down`
+- Reset to fresh-install: `docker compose -f docker-compose.manual.yml down && rm -rf manual-test/data/database/* && docker compose -f docker-compose.manual.yml up --build -d`
+
+If you need a fresh manual stack and it doesn't exist yet, look at `docker-compose.example.yml` (committed) for the recommended layout, or recreate `docker-compose.manual.yml` with `Dockerfile.prod`, port 3001, `manual-test/` mount, and `ADMIN_NAME`/`ADMIN_PASSWORD` envs.
+
+### Worktree state
+
+Work happened in a worktree at `E:/skillgoblin/.claude/worktrees/wizardly-cohen-224f57/`. The main repo is at `E:/skillgoblin/`. Both worktrees share the same git database; `main` is checked out in the main worktree. Don't try to `git checkout main` from the worktree — it'll fail with "already used by worktree at E:/skillgoblin". Make new feature branches with `git checkout -b <name> origin/main`.
+
+### Lockfile changes (rare)
+
+If you bump a frontend dep, regenerate the lockfile *inside Docker* (host build is broken):
 ```bash
 MSYS_NO_PATHCONV=1 docker run --rm \
   -v "$(pwd -W)/frontend:/work" -w "//work" node:18-alpine \
@@ -107,46 +151,28 @@ MSYS_NO_PATHCONV=1 docker run --rm \
 ```
 
 ### Codex setup
+
 - Plugin at `C:/Users/vlado/.claude/plugins/cache/openai-codex/codex/1.0.2/`
-- Codex CLI at v0.125.0 — npm latest at handover time was 0.128.0; bumping is optional.
 - Auth: already done. If `codex --version` says `unauthenticated`, run `codex login`.
 
 ---
 
-## Known follow-ups (not blockers, deferred from earlier reviews)
+## Architectural cheat sheet (30-second version)
 
-These are real but small enough to defer past the PR. Each is documented in the relevant phase commit body.
-
-| Item | Why deferred | Lives in |
-|---|---|---|
-| `X-Forwarded-Proto` and `X-Forwarded-For` are trusted unconditionally | Acceptable behind a real reverse proxy (the recommended deployment); not exploitable through normal use | `frontend/server/middleware/session.js`, `frontend/server/api/users/auth.js` |
-| `touchSession` updates without a `changes` check | Race with logout/revoke briefly re-issues a cookie for an already-deleted row; next request clears it. Not a privilege escalation | `frontend/server/utils/sessions.js` |
-| `/api/users/[id]` GET still leaks `isAdmin`, `is_active`, `has_password`, `has_pin` | The login picker needs these | `frontend/server/api/users/[id].js` |
-| Migration runner uses raw `BEGIN`; nested transactions in future migrations would conflict | No migration uses nested transactions yet; swap to `db.transaction()` when needed | `frontend/server/utils/migrations.js` |
-| `001_initial` thumbnail_data column ordering differs between fresh and upgraded installs | Harmless for named queries; only matters if `SELECT *` code is ever introduced | `frontend/server/migrations/001_initial.js` |
-| `UserManagement.vue` doesn't yet show an encourage-both hint in the change/switch tabs | Phase 4 admin-panel polish | `frontend/components/UserManagement.vue` |
-| Bootstrap-credentials success-path e2e is gap | Would need a fixture that inserts a legacy no-creds row, since signup refuses to create one. Unit-level coverage of the failure cases is in place | `frontend/tests/e2e/upgrade-flows.spec.js` |
-| Rate limiter is per-process; cluster mode would have separate buckets | We don't run cluster mode; documented in the file | `frontend/server/utils/rate-limit.js` |
+- **Auth:** `sg_session` cookie (HttpOnly, SameSite=Lax, 30-day) issued by `/api/users/auth`. Server middleware [session.js](frontend/server/middleware/session.js) reads it, populates `event.context.user`, slides expiry forward (debounced 5 min).
+- **Authz:** every mutating endpoint calls one of `requireAuth` / `requireAdmin` / `requireSelfOrAdmin` from [authz.js](frontend/server/utils/authz.js). Static rule: no caller can act on someone else unless admin; mutations of role / activation are admin-only.
+- **Credentials:** argon2id. Legacy plaintext detected on read and rehashed inline. Every account must have at least one of password / PIN; server enforces on POST and PUT.
+- **PIN bridge:** PIN auth permitted when `allow_pin=true` OR user has no password (the one-time bridge). After bridge auth, response carries `needsCredentialUpdate: 'pin_disabled'` so the frontend prompts for a password. Server's PUT no longer auto-clears PINs when `allow_pin=false` — leaves them in place for if the operator re-enables.
+- **Sessions:** opaque base64url tokens, sha256-hashed in DB, one row per active session. Survive container restarts. Admin "kick" + user "log out all devices" both `DELETE FROM user_sessions WHERE …`.
+- **System policy:** `system_settings` table. Two known keys today — `allow_pin` and `auto_approve_new_users`. Read via public GET, written via admin-only PUT. Whitelist + boolean coercion in the endpoint.
+- **Last-admin protection:** any change leaving zero active admins is refused with 409.
+- **First-run:** server plugin [bootstrap.js](frontend/server/plugins/bootstrap.js) refuses to start on a fresh install if `ADMIN_NAME`/`ADMIN_PASSWORD` env aren't set.
+- **Modal pattern:** every modal supports backdrop dismiss + X/Cancel; in-flight saves guard the dismiss path so an accidental click-out can't hide a pending failure.
 
 ---
 
-## Architectural cheat sheet
+## Recommended starting slice
 
-The full map is `notes/architecture-map.md`. The 30-second version after Phase 3:
+If the user is open to a recommendation: **course content polish (B)**. It improves the existing libraries materially (subtitles working out of the box, course.json overrides, per-lesson README) and operators feel the value immediately. Customization (A) is more cosmetic. UI polish (C) is small enough to bundle with whichever you do.
 
-- **Auth:** cookie session (`sg_session`, HttpOnly, SameSite=Lax, 30-day) issued by `/api/users/auth`. Server middleware `frontend/server/middleware/session.js` reads it, populates `event.context.user`, and slides `expires_at` forward (debounced 5 min).
-- **Authz:** every mutating endpoint calls one of `requireAuth` / `requireAdmin` / `requireSelfOrAdmin` from `frontend/server/utils/authz.js`. The static check is "no caller can act on someone else unless they're admin"; mutations of role / activation are admin-only.
-- **Credentials:** argon2id at rest (`frontend/server/utils/credentials.js`). Legacy plaintext rows are detected on read and rehashed inline. Every account must have at least one of password / PIN; the server enforces that on POST and PUT.
-- **System policy:** `system_settings` table. Two known keys today — `allow_pin` and `auto_approve_new_users`. Read via public GET, written via admin-only PUT. Whitelist + boolean coercion in the endpoint guards against pollution.
-- **Last-admin protected:** any change that would leave the system with zero active admins (demote / deactivate / delete) is refused with 409.
-- **First-run:** Nitro server plugin `frontend/server/plugins/bootstrap.js` refuses to start on a fresh install if `ADMIN_NAME` / `ADMIN_PASSWORD` env aren't set.
-
----
-
-## When you start a fresh session
-
-1. `cd E:/skillgoblin/.claude/worktrees/wizardly-cohen-224f57`
-2. `git log --oneline -6` — confirm you're on `feat/auth-hardening` past `66f1223`.
-3. Read `notes/feature-wishlist.md` (locked decisions) and the phase commit bodies in order. The "Phase 4 — admin panel UI" section above is the next chunk of work.
-4. Run the test suite once to make sure your environment is good: `docker compose -f docker-compose.test.yml run --rm tests`.
-5. Pick up from Phase 4. Same workflow as Phases 0–3 (per-phase commits, Codex review before each commit, tests green before each commit).
+But that's a recommendation, not a decision — wait for the user's pick.


### PR DESCRIPTION
The previous \`notes/handover.md\` described work-in-progress on Phase 4–5 of auth-hardening — all of which is now shipped on main via PRs #6 and #7. This refreshes it with a cold-start brief for the **next** round of work, intended for picking up after a context clear.

## What the new handover covers

- **TL;DR**: what's already done (auth, admin panel, credential UX, modal dismiss); current test counts (75 unit + 82 e2e green).
- **Hard rules**: no Claude attribution in commits, tests in Docker only, migrations forward-only, Codex review pattern via direct Bash invocation.
- **What's left** — the remaining wishlist categories laid out as A/B/C/D so a fresh session can pick:
  - A. Customization / branding (app name, theme color, custom logo, dynamic web manifest)
  - B. Course content polish (course.json, SRT→VTT, per-lesson README, captions distinction)
  - C. UI polish (icons in dropdown, avatar live preview)
  - D. Deferred quality items (small carryovers from the auth work)
- **Architectural cheat sheet** (30-second version): auth model, sessions, authz layers, credential floor, PIN bridge, system_settings, last-admin guard.
- **Local environment**: manual-test stack location and recipe, worktree layout (main is checked out elsewhere — don't \`git checkout main\` from a worktree), Docker-only lockfile regeneration recipe, Codex CLI setup.
- **"Wait for the user's first message"** — explicit so the next session doesn't pre-empt the slice choice.

## Why this is its own PR

Pure docs update, zero code changes. Lands cleanly on main without touching the test suite or any feature surface.