### PR TITLE
feat(ui): logout + delete-account icons; sticky avatar preview

### DIFF
--- a/frontend/components/UserManagement.vue
+++ b/frontend/components/UserManagement.vue
@@ -28,13 +28,15 @@
           />
         </div>
         
-        <!-- Avatar preview -->
+        <!-- Avatar preview — sticky so it stays visible while the user
+             scrolls through the AvatarSelector options below, giving a
+             true live preview of every change. -->
         <ClientOnly>
-          <div class="mb-4">
+          <div class="sticky top-0 z-10 bg-gray-800 pt-2 pb-4 -mt-2 mb-4">
             <h3 class="block text-sm font-medium text-gray-300 mb-1">Avatar Preview</h3>
             <div class="flex justify-center">
               <div class="w-24 h-24 rounded-full overflow-hidden bg-gray-700 flex items-center justify-center">
-                <Beanhead 
+                <Beanhead
                   v-if="isValidAvatarJson(userData.avatar)"
                   v-bind="parseAvatar(userData.avatar)"
                   width="96"

--- a/frontend/components/UserProfile.vue
+++ b/frontend/components/UserProfile.vue
@@ -67,17 +67,27 @@
           </span>
         </button>
         
-        <button 
-          @click="logout" 
+        <button
+          @click="logout"
           class="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
         >
-          Logout
+          <span class="flex items-center">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+            </svg>
+            Logout
+          </span>
         </button>
-        <button 
-          @click="confirmDelete" 
+        <button
+          @click="confirmDelete"
           class="block w-full text-left px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-600"
         >
-          Delete Account
+          <span class="flex items-center">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+            </svg>
+            Delete Account
+          </span>
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Wishlist slice C polish items:
- User dropdown menu — outline icons next to **Logout** (door + arrow) and **Delete Account** (trash), matching the existing icons on Admin Panel / Rescan Database / My Profile.
- My Profile editor avatar preview — `position: sticky` so it stays visible at the top of the modal while the user scrolls through the AvatarSelector options below. Vue reactivity already updated the preview live; the issue was visibility on smaller screens.

## Test plan
- ✅ 103 Playwright + 98 vitest = 201 tests green in Docker. Existing dropdown tests use button text/role selectors which are preserved.