### PR TITLE
ci: add Dependabot, CodeQL, Trivy, OSSF Scorecard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,52 @@
+# Dependabot — automated dependency vulnerability scanning + update PRs.
+#
+# Watches two ecosystems:
+#   1. npm  — the frontend Nuxt app (package.json lives in frontend/)
+#   2. github-actions — the workflow files in this directory
+#
+# Schedule: weekly. Avoids PR storms while keeping deps fresh enough that
+# CVE-fix updates land within ~7 days. Bump to "daily" if you want
+# faster security response (~24h).
+#
+# Grouping: minor + patch updates batch into one PR per ecosystem so
+# routine bumps don't drown the inbox; majors get their own PRs because
+# they're more likely to need attention.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Bratislava
+    open-pull-requests-limit: 10
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+      - npm
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Bratislava
+    open-pull-requests-limit: 5
+    groups:
+      gha-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,59 @@
+# CodeQL — GitHub-native SAST (static analysis security testing).
+#
+# Catches: SQL injection, XSS, hardcoded credentials, path traversal,
+# insecure cookie flags, prototype pollution, eval-on-user-input, etc.
+# Findings show up in the repo's Security tab and as PR annotations.
+#
+# Free for public repos with no minute cap.
+# Uses GitHub's "security-and-quality" query suite (broader than
+# default — catches lower-severity-but-real issues too).
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly Monday 03:00 UTC — picks up new CodeQL queries against the
+    # current main even when no commits land.
+    - cron: "0 3 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze JavaScript/Vue
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # 'javascript-typescript' covers .js, .ts, AND .vue templates.
+        # If we ever add Python, Go, etc. add another entry here.
+        language: [javascript-typescript]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      # Autobuild handles the JS path automatically (no compile step
+      # needed for an interpreted language). Listed explicitly so a
+      # future move to TypeScript with a build step still works.
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,59 @@
+# OpenSSF Scorecard — automated scoring against ~20 supply-chain &
+# repo-hygiene best practices.
+#
+# Scores 0-10. Findings (e.g. "branch protection not enforced", "no
+# code review required", "binaries committed", "permissive Actions
+# permissions") show up in the Security tab. The badge in the README
+# updates within minutes of each run.
+#
+# Runs weekly + on every push to main. The publish_results step uploads
+# scores to https://api.securityscorecards.dev so the badge URL works.
+name: Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "30 3 * * 1"
+  workflow_dispatch:
+
+# Token permissions: minimum required for Scorecard to read repo state
+# and write its findings to the Security tab.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    permissions:
+      security-events: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish results so the badge URL works:
+          # https://api.securityscorecards.dev/projects/github.com/<owner>/<repo>/badge
+          publish_results: true
+
+      - name: Upload artifact (SARIF)
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,85 @@
+# Trivy — vulnerability + misconfiguration scanner from Aqua Security.
+#
+# Two scans:
+#   1. Filesystem scan — finds known CVEs in npm dependencies (overlaps
+#      with Dependabot but uses a different CVE feed; combined coverage
+#      catches more) and secret-leak patterns.
+#   2. Config scan — analyzes the Dockerfile + docker-compose files for
+#      misconfigurations (running as root, missing healthchecks, world-
+#      writable paths, etc.).
+#
+# Findings → SARIF → Security tab. PR-blocking on CRITICAL + HIGH;
+# MEDIUM and below are reported but don't fail the run.
+name: Trivy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "45 3 * * 1"
+
+jobs:
+  trivy-filesystem:
+    name: Trivy filesystem scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          # Scans node deps + secrets. Skip the noisy unmanaged-package
+          # checks; rely on Dependabot for the npm-CVE catch.
+          scanners: vuln,secret
+          severity: CRITICAL,HIGH,MEDIUM
+          format: sarif
+          output: trivy-fs.sarif
+          exit-code: "0" # report only — don't fail the run on findings
+
+      - name: Upload Trivy filesystem SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-fs.sarif
+          category: trivy-fs
+
+  trivy-config:
+    name: Trivy config scan (Dockerfile + compose)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Trivy config scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: config
+          scan-ref: .
+          severity: CRITICAL,HIGH,MEDIUM
+          format: sarif
+          output: trivy-config.sarif
+          exit-code: "0"
+
+      - name: Upload Trivy config SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-config.sarif
+          category: trivy-config

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # SkillGoblin
 
+[![CodeQL](https://github.com/VladoPortos/skillgoblin/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/VladoPortos/skillgoblin/actions/workflows/codeql.yml)
+[![Trivy](https://github.com/VladoPortos/skillgoblin/actions/workflows/trivy.yml/badge.svg?branch=main)](https://github.com/VladoPortos/skillgoblin/actions/workflows/trivy.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/VladoPortos/skillgoblin/badge)](https://scorecard.dev/viewer/?uri=github.com/VladoPortos/skillgoblin)
+
 A streamlined, self-hosted learning platform focused on simplicity and ease of maintenance.
 
 ## Project Vision


### PR DESCRIPTION
## Summary
Four free-for-public-repo automated security/quality checks, plus README badges.

- **Dependabot** (`.github/dependabot.yml`) — weekly npm + github-actions dep scans. Auto-creates batched minor/patch update PRs.
- **CodeQL** (`.github/workflows/codeql.yml`) — SAST on push to main + PR + weekly. `security-and-quality` query suite.
- **OpenSSF Scorecard** (`.github/workflows/scorecard.yml`) — supply-chain best-practice scoring, publishes badge.
- **Trivy** (`.github/workflows/trivy.yml`) — filesystem CVE scan + Dockerfile/compose misconfig scan. Non-blocking; findings go to the Security tab.

All findings will surface in the **Security** tab once workflows run after merge. Dependabot starts immediately; CodeQL/Trivy/Scorecard run their first scan within ~5 min of merge.

## Test plan
- [ ] After merge, check Actions tab — all 4 workflows appear and the first runs of CodeQL/Trivy/Scorecard succeed.
- [ ] Security tab populates with any findings.
- [ ] README badges render (CodeQL + Trivy badges go green/red based on first run; Scorecard badge takes ~30 min for first publish).