### PR TITLE
chore: cleanup unused locals + lock line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+# Normalize all text files to LF on checkin and checkout. Without this,
+# Windows clones with core.autocrlf=true ship CRLF into the working tree,
+# which breaks `frontend/scripts/entrypoint.sh` inside the Linux container
+# (the kernel reads `#!/bin/sh\r` and exits 127).
+* text=auto eol=lf
+
+# Belt-and-suspenders for the files where wrong line endings break execution.
+*.sh text eol=lf
+
+# Don't normalize binaries (this list is not exhaustive — `text=auto` above
+# already detects most binary files, but pinning the obvious ones is safer).
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.mp4 binary
+*.webp binary

--- a/frontend/server/api/users/index.js
+++ b/frontend/server/api/users/index.js
@@ -2,7 +2,7 @@ import { defineEventHandler, readBody, createError } from 'h3';
 import { v4 as uuidv4 } from 'uuid';
 import { getDb } from '../../utils/db';
 import { hashCredential } from '../../utils/credentials';
-import { requireAdmin, requireSelfOrAdmin } from '../../utils/authz';
+import { requireSelfOrAdmin } from '../../utils/authz';
 import { deleteUserSessions } from '../../utils/sessions';
 import { ensureNotLastAdmin } from '../../utils/lastAdminGuard';
 

--- a/frontend/tests/e2e/admin-panel.spec.js
+++ b/frontend/tests/e2e/admin-panel.spec.js
@@ -214,7 +214,7 @@ test.describe('AdminPanel — row actions', () => {
 
   test('promote then demote a regular user', async ({ page }) => {
     const { pleb } = await createPendingPleb(page.request, 'role');
-    const admin = await openPanelAsAdmin(page);
+    await openPanelAsAdmin(page);
 
     // Activate first so we can verify role transitions independent of activation.
     const row = page.getByTestId(`user-row-${pleb.id}`);

--- a/frontend/tests/e2e/branding-runtime-env.spec.js
+++ b/frontend/tests/e2e/branding-runtime-env.spec.js
@@ -8,11 +8,7 @@
 // this test only asserts the runtime-config-driven shape. The actual
 // "with APP_NAME=Foo, the page shows Foo" verification is in the
 // manual smoke step.
-import { test, expect, request as pwRequest } from '@playwright/test';
-
-async function freshContext() {
-  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://app:3000' });
-}
+import { test, expect } from '@playwright/test';
 
 test.describe('Runtime branding wiring', () => {
   test('useRuntimeConfig().public.branding reaches the client', async ({ page }) => {

--- a/frontend/tests/unit/sessions.test.js
+++ b/frontend/tests/unit/sessions.test.js
@@ -13,7 +13,6 @@ import {
   pruneExpiredSessions,
   hashSessionToken,
   generateSessionToken,
-  SESSION_LIFETIME_MS,
   SESSION_TOUCH_DEBOUNCE_MS
 } from '../../server/utils/sessions.js';
 


### PR DESCRIPTION
## Summary

Two small chores in one branch — both are pre-work for the Dependabot triage round and clear backlog items off the security tab.

### 1. Lock line endings to LF (`.gitattributes`)
Windows clones with `core.autocrlf=true` were converting `frontend/scripts/entrypoint.sh` to CRLF on checkout, which made the Linux container fail with exit 127 (`exec: line 11: ... not found` because the shebang ended with `\r`). Adds `* text=auto eol=lf` plus a belt-and-suspenders `*.sh text eol=lf` and binary excludes for common image/video extensions.

No file content actually changed in git — the index already had everything as LF. The `.gitattributes` is just protection against future Windows checkouts.

### 2. Remove unused locals flagged by CodeQL (4 findings)
- `frontend/server/api/users/index.js`: `requireAdmin` import (file goes through `requireSelfOrAdmin` + `system_settings` gating instead).
- `frontend/tests/unit/sessions.test.js`: `SESSION_LIFETIME_MS` import.
- `frontend/tests/e2e/admin-panel.spec.js`: `admin` const in the promote/demote test — assigned but never read. `openPanelAsAdmin` still runs for its side effects.
- `frontend/tests/e2e/branding-runtime-env.spec.js`: `freshContext()` helper (never called) + its sole-purpose `pwRequest` import.

## Test plan

- [x] Docker test suite: 80 vitest + 103 Playwright, all green pre-edit (after fixing entrypoint line endings)
- [x] Docker test suite: same green count post-edit
- [x] No real diff on the 130 working-tree files after `git add --renormalize .` — index storage unchanged