### PR TITLE
chore: bump Node 18 -> 20

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS builder
+FROM node:20-alpine AS builder
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ COPY frontend ./
 # Build the application
 RUN npm run build
 
-FROM node:18-alpine
+FROM node:20-alpine
 
 WORKDIR /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   skillgoblin:
-    image: node:18-alpine
+    image: node:20-alpine
     working_dir: /app
     volumes:
       - ./:/app


### PR DESCRIPTION
## Summary

Bumps the runtime base image from `node:18-alpine` to `node:20-alpine` in two places:
- `Dockerfile.prod` (both build + runtime stages)
- `docker-compose.yml` (the dev compose file)

## Why now

Several Dependabot library majors waiting in the queue require Node 20+:
- chokidar 5 (#21) — `>= 20.19.0`
- lru-cache 11 (#26) — `20 || >=22`
- vitest 4 (#22) — needs Node 20+ for current stable
- readdirp 5 (transitive) — `>= 20.19.0`
- Nuxt 4 (#25, eventually) — same family

This unblocks step 3 of the upgrade plan. Node 18 also hits EOL April 2025, so we'd have done this anyway.

## Test plan

- [x] Native modules (`better-sqlite3 9.x`, `argon2 0.41.x`, `sharp 0.33.5`) recompile cleanly against Node 20 alpine
- [x] Docker test stack: 11 vitest files / 98 tests + 103 Playwright = green
- [x] No application code changes — pure infra

## Out of scope

- Updating the migration comment at `frontend/server/migrations/002_auth_hardening.js:15` referencing Node 18. The SQLite version statement (3.42+) it makes is still accurate, and the comment will be revisited when better-sqlite3 itself bumps in #24.