### PR TITLE
chore: bump @playwright/test 1.48 -> 1.59 (via service rename app -> web to dodge .app HSTS preload)

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,17 +1,27 @@
 # Test orchestration. Two services:
-#   - `app`: production build of SkillGoblin, fresh DB on every run.
+#   - `web`: production build of SkillGoblin, fresh DB on every run.
 #   - `tests`: official Playwright image, runs the unit + e2e suites
-#             against the `app` service over the compose network.
+#             against the `web` service over the compose network.
 #
 # Run with:  docker compose -f docker-compose.test.yml run --rm tests
 #
 # Adds `--build` if you've changed the app image:
-#   docker compose -f docker-compose.test.yml up --build -d app
+#   docker compose -f docker-compose.test.yml up --build -d web
 #   docker compose -f docker-compose.test.yml run --rm tests
 #   docker compose -f docker-compose.test.yml down -v
+#
+# Service hostname history: this used to be named `app`. Chromium's
+# HSTS preload list hardcodes the `.app` gTLD as HTTPS-only — every
+# `*.app` host (including the bare label `app`) gets HTTP traffic
+# auto-upgraded to HTTPS. From Chrome 132+ this kicked in for
+# Playwright-driven navigations and broke `page.goto('http://app:3000')`
+# with `net::ERR_SSL_PROTOCOL_ERROR`. There is no Chromium flag that
+# disables hardcoded HSTS preloads (it's a security guarantee, not a
+# feature flag). Renaming to a label outside any preloaded TLD (`web`
+# is not preloaded) is the supported workaround.
 
 services:
-  app:
+  web:
     build:
       context: .
       dockerfile: Dockerfile.prod
@@ -41,16 +51,16 @@ services:
       start_period: 5s
 
   tests:
-    image: mcr.microsoft.com/playwright:v1.48.2-jammy
+    image: mcr.microsoft.com/playwright:v1.59.1-jammy
     depends_on:
-      app:
+      web:
         condition: service_healthy
     working_dir: /work
     volumes:
       - ./frontend:/work
       - tester_node_modules:/work/node_modules
     environment:
-      - PW_BASE_URL=http://app:3000
+      - PW_BASE_URL=http://web:3000
       - PW_ADMIN_NAME=root
       - PW_ADMIN_PASSWORD=TestAdminPass!
       - CI=1

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,7 +21,7 @@
         "tailwindcss": "^4.2.4"
       },
       "devDependencies": {
-        "@playwright/test": "1.48.2",
+        "@playwright/test": "1.59.1",
         "glob": "^10.3.10",
         "uuid": "^14.0.0",
         "vitest": "^4.1.5"
@@ -3308,13 +3308,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.48.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.2.tgz",
-      "integrity": "sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.48.2"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -8513,13 +8513,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.48.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.2.tgz",
-      "integrity": "sha512-NjYvYgp4BPmiwfe31j4gHLa3J7bD2WiBz8Lk2RoSsmX38SVIARZ18VYjxLjAcDsAhA+F4iSEXTSGgjua0rrlgQ==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.48.2"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -8532,9 +8532,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.48.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.2.tgz",
-      "integrity": "sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "busboy": "^1.6.0"
   },
   "devDependencies": {
-    "@playwright/test": "1.48.2",
+    "@playwright/test": "1.59.1",
     "uuid": "^14.0.0",
     "glob": "^10.3.10",
     "vitest": "^4.1.5"

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -2,10 +2,10 @@ import { defineConfig, devices } from '@playwright/test';
 
 // Tests are intended to run inside the dockerized test runner
 // (see docker-compose.test.yml at the repo root). The runner reaches the app
-// over the docker network at http://app:3000 by default. The PW_BASE_URL env
+// over the docker network at http://web:3000 by default. The PW_BASE_URL env
 // var lets you override for local debugging if you ever spin up an app
 // outside of compose.
-const baseURL = process.env.PW_BASE_URL || 'http://app:3000';
+const baseURL = process.env.PW_BASE_URL || 'http://web:3000';
 
 export default defineConfig({
   testDir: './tests/e2e',

--- a/frontend/tests/e2e/admin-panel.spec.js
+++ b/frontend/tests/e2e/admin-panel.spec.js
@@ -4,7 +4,7 @@ const ADMIN_NAME = process.env.PW_ADMIN_NAME || 'root';
 const ADMIN_PASSWORD = process.env.PW_ADMIN_PASSWORD || 'TestAdminPass!';
 
 async function freshContext() {
-  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://app:3000' });
+  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://web:3000' });
 }
 
 async function getAdmin(request) {

--- a/frontend/tests/e2e/branding.spec.js
+++ b/frontend/tests/e2e/branding.spec.js
@@ -1,7 +1,7 @@
 import { test, expect, request as pwRequest } from '@playwright/test';
 
 async function freshContext() {
-  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://app:3000' });
+  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://web:3000' });
 }
 
 test.describe('GET /api/webmanifest', () => {

--- a/frontend/tests/e2e/credential-flows.spec.js
+++ b/frontend/tests/e2e/credential-flows.spec.js
@@ -7,7 +7,7 @@ const ADMIN_NAME = process.env.PW_ADMIN_NAME || 'root';
 const ADMIN_PASSWORD = process.env.PW_ADMIN_PASSWORD || 'TestAdminPass!';
 
 async function freshContext() {
-  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://app:3000' });
+  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://web:3000' });
 }
 
 async function getAdmin(request) {

--- a/frontend/tests/e2e/modal-dismiss.spec.js
+++ b/frontend/tests/e2e/modal-dismiss.spec.js
@@ -8,7 +8,7 @@ const ADMIN_NAME = process.env.PW_ADMIN_NAME || 'root';
 const ADMIN_PASSWORD = process.env.PW_ADMIN_PASSWORD || 'TestAdminPass!';
 
 async function freshContext() {
-  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://app:3000' });
+  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://web:3000' });
 }
 
 async function getAdmin(request) {

--- a/frontend/tests/e2e/pin-disabled-upgrade.spec.js
+++ b/frontend/tests/e2e/pin-disabled-upgrade.spec.js
@@ -9,7 +9,7 @@ const ADMIN_NAME = process.env.PW_ADMIN_NAME || 'root';
 const ADMIN_PASSWORD = process.env.PW_ADMIN_PASSWORD || 'TestAdminPass!';
 
 async function freshContext() {
-  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://app:3000' });
+  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://web:3000' });
 }
 
 async function getAdmin(request) {

--- a/frontend/tests/e2e/registration-lock.spec.js
+++ b/frontend/tests/e2e/registration-lock.spec.js
@@ -4,7 +4,7 @@ const ADMIN_NAME = process.env.PW_ADMIN_NAME || 'root';
 const ADMIN_PASSWORD = process.env.PW_ADMIN_PASSWORD || 'TestAdminPass!';
 
 async function freshContext() {
-  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://app:3000' });
+  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://web:3000' });
 }
 
 async function getAdmin(request) {

--- a/frontend/tests/e2e/sessions.spec.js
+++ b/frontend/tests/e2e/sessions.spec.js
@@ -11,7 +11,7 @@ async function getAdmin(request) {
 
 // Each test uses a fresh request context so session cookies don't leak across tests.
 async function freshContext() {
-  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://app:3000' });
+  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://web:3000' });
 }
 
 test.describe('session lifecycle', () => {

--- a/frontend/tests/e2e/upgrade-flows.spec.js
+++ b/frontend/tests/e2e/upgrade-flows.spec.js
@@ -4,7 +4,7 @@ const ADMIN_NAME = process.env.PW_ADMIN_NAME || 'root';
 const ADMIN_PASSWORD = process.env.PW_ADMIN_PASSWORD || 'TestAdminPass!';
 
 async function freshContext() {
-  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://app:3000' });
+  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://web:3000' });
 }
 async function getAdmin(request) {
   const r = await request.get('/api/users');

--- a/notes/customization-branding-plan.md
+++ b/notes/customization-branding-plan.md
@@ -270,7 +270,7 @@ Create `frontend/tests/e2e/branding.spec.js`:
 import { test, expect, request as pwRequest } from '@playwright/test';
 
 async function freshContext() {
-  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://app:3000' });
+  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://web:3000' });
 }
 
 test.describe('GET /api/webmanifest', () => {

--- a/notes/handover.md
+++ b/notes/handover.md
@@ -8,10 +8,9 @@ The user's first message after `/clear` will tell you what to work on next. Unti
 
 ## TL;DR
 
-- **Repo:** SkillGoblin — self-hosted homelab learning platform. **Nuxt 4.x + Tailwind 4.x** + better-sqlite3 12.x SQLite + argon2 0.44 + sharp 0.34 + Playwright 1.48.2 (held). SPA mode (`ssr: false`). Designed for trusted local networks.
-- **State of `main`:** auth + admin + branding + UI polish + CI + .gitattributes-locked LF + Node 20 + 22 patch/minor bumps + Nuxt 4 + Tailwind 4 (CSS-first via `@tailwindcss/vite`) + argon2/beanheads-vue/sharp safe bumps shipped. Last merged commit: `999e5f0`.
-- **What's open: 0 PRs.** First time the queue is fully drained.
-- **Held back:** [`@playwright/test 1.48.2 → 1.59.x`](#held-back-playwright-159--chrome-141-https-upgrade) — see the lesson below. Worth a dedicated debugging session, not blocking other work.
+- **Repo:** SkillGoblin — self-hosted homelab learning platform. **Nuxt 4.x + Tailwind 4.x** + better-sqlite3 12.x SQLite + argon2 0.44 + sharp 0.34 + Playwright 1.59.1. SPA mode (`ssr: false`). Designed for trusted local networks.
+- **State of `main`:** auth + admin + branding + UI polish + CI + .gitattributes-locked LF + Node 20 + 22 patch/minor bumps + Nuxt 4 + Tailwind 4 (CSS-first via `@tailwindcss/vite`) + argon2/beanheads-vue/sharp + Playwright 1.59 (with the docker test service renamed `app` → `web` to dodge the `.app` HSTS preload) shipped.
+- **What's open: 0 PRs** at the time this doc was written. First time the queue is fully drained.
 - **The user's first message after `/clear`** will pick a slice. Don't pre-empt.
 
 ---
@@ -101,12 +100,10 @@ Tailwind 4's PostCSS-replacement compiler can't resolve utility names that come 
 ### 4. `sed -E 's/(\b)shadow(\b)([^-])/.../'` for bare-utility renames catches CSS properties
 Renaming bare Tailwind `shadow` → `shadow-sm` looks like a clean word-boundary problem, but the regex `\bshadow\b[^-]` matches inside `box-shadow: ...` (because `:` isn't a hyphen) and inside `transition-shadow ` (because both `shadow` boundaries are preserved). My first run silently produced `box-shadow-sm: 0 4px ...` and `transition-shadow-sm` across 5 files. **Always run a `grep -rEn 'box-shadow|transition-shadow|drop-shadow' --include="*.vue" .` after a bare-utility rename and confirm no compound utilities or CSS properties got caught.** Recovery is a targeted reverse-sed for each compound (`box-shadow-sm: → box-shadow:`, `transition-shadow-sm → transition-shadow`).
 
-### Held back: Playwright 1.59 + Chrome 141 HTTPS upgrade
-**TL;DR: don't bump `@playwright/test` past 1.48.2 without solving the HTTPS-upgrade issue first.**
+### 5. Don't name a docker service after a hostname Chromium has HSTS-preloaded (`.app`, `.dev`, `.foo`, `.page`, …)
+**This bit hard.** When [#58](https://github.com/VladoPortos/skillgoblin/pull/58) bumped `@playwright/test` from 1.48 to 1.59 (and the docker image to match), 46 of 103 Playwright tests started failing with `Error: page.goto: net::ERR_SSL_PROTOCOL_ERROR at http://app:3000/...`. Chromium was forcing HTTPS on every browser-driven navigation, even though `page.request.*` (raw HTTP, no browser) worked fine.
 
-When [#58](https://github.com/VladoPortos/skillgoblin/pull/58) (`@playwright/test 1.48 → 1.59`) was attempted as part of [#62](https://github.com/VladoPortos/skillgoblin/pull/62), the coordinated change was straightforward: bump the npm package + bump `mcr.microsoft.com/playwright:v1.48.2-jammy` → `v1.59.1-jammy` in `docker-compose.test.yml`. The build succeeded, but **46 of 103 Playwright tests failed** with `Error: page.goto: net::ERR_SSL_PROTOCOL_ERROR at http://app:3000/...`.
-
-Root cause: Chrome 141 (which Playwright 1.59 ships) auto-upgrades non-localhost HTTP requests to HTTPS. Our docker test runner reaches the app over the docker network at `http://app:3000` — not localhost — so Chrome attempts an HTTPS handshake against a plain-HTTP server. None of the standard mitigations took effect against the Playwright-bundled Chromium build:
+We initially blamed Chrome 141's auto-HTTPS-upgrade feature and tried every disable-flag we could find:
 
 ```js
 launchOptions: {
@@ -118,15 +115,13 @@ launchOptions: {
 }
 ```
 
-Page.request (raw HTTP, no browser) calls work — only `page.goto()` and other browser-driven navigations fail. So the API-only tests pass and the rendering tests fail.
+None of them worked. That was the clue.
 
-For #62 we kept the safe bumps (argon2 / beanheads-vue / sharp) and held @playwright/test on 1.48.2. The proper fix probably needs one of:
-- A different flag combination that actually disables the upgrade in Playwright-bundled Chromium
-- TLS termination in front of the test app (heavyweight)
-- A Playwright-team-side fix or workaround
-- Switching the test runner to bind to host network so `localhost:3000` works
+**Real cause:** the docker test service was named `app`. Chromium's HSTS preload list hardcodes the `.app` gTLD as HTTPS-only (Google bought `.app` and registered it that way in 2018; same applies to `.dev`, `.foo`, `.page`, `.new`, `.search`, `.zip`, `.mov`). Every host on those TLDs — including the bare label `app` resolving via docker DNS — gets HTTPS forced. **Hardcoded HSTS preloads are a security guarantee, not a feature flag** — there is no Chromium command-line argument that disables them. Workarounds like `--unsafely-treat-insecure-origin-as-secure` don't bypass the preload because the preload kicks in earlier in the request lifecycle.
 
-This is worth a dedicated debugging session, **not** a quick mid-Dependabot-sweep retry.
+**Fix:** rename the docker service to a label outside any preloaded TLD. We picked `web`. Two-line change in `docker-compose.test.yml` (service name + `PW_BASE_URL`) plus updating the hardcoded fallback in `frontend/playwright.config.js` and the eight `tests/e2e/*.spec.js` files that copy-paste the same fallback. Once renamed, Playwright 1.59 + Chrome 141 work without any flags. Shipped in the same commit as the bump.
+
+For future you: if a Playwright/Chrome bump suddenly starts failing browser navigations with SSL errors on a hostname that previously worked, **check the HSTS preload list before fighting flags**. The list lives at https://chromium.googlesource.com/chromium/src/+/main/net/http/transport_security_state_static.json. Single-label hosts are matched against it just like full domains are.
 
 ---
 
@@ -142,7 +137,6 @@ This is worth a dedicated debugging session, **not** a quick mid-Dependabot-swee
    ```
    Should print 11 vitest files / 98 tests + 103 Playwright passed. If not — investigate before doing anything else.
 4. **Wait for the user's first message** to pick the slice. Likely picks:
-   - **"Debug Playwright 1.59"** — see the HTTPS-upgrade lesson above. Worth a focused investigation.
    - **A new feature** — course content polish, fresh capability, etc.
    - **Triage any new dependabot PRs that landed since the sweep.**
 5. **Don't assume** — wait for direction.

--- a/notes/registration-lock-plan.md
+++ b/notes/registration-lock-plan.md
@@ -333,7 +333,7 @@ const ADMIN_NAME = process.env.PW_ADMIN_NAME || 'root';
 const ADMIN_PASSWORD = process.env.PW_ADMIN_PASSWORD || 'TestAdminPass!';
 
 async function freshContext() {
-  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://app:3000' });
+  return pwRequest.newContext({ baseURL: process.env.PW_BASE_URL || 'http://web:3000' });
 }
 
 async function getAdmin(request) {


### PR DESCRIPTION
## Summary

Resurrects the `@playwright/test` bump that was held back from [#62](https://github.com/VladoPortos/skillgoblin/pull/62). Now that we know the real root cause (Chromium's `.app` HSTS preload, not Chrome 141's HTTPS-upgrade feature) the fix is a one-line service rename.

### What changed
- `@playwright/test` 1.48.2 → 1.59.1
- `mcr.microsoft.com/playwright` image v1.48.2-jammy → v1.59.1-jammy
- `docker-compose.test.yml` service: `app` → `web`
- `PW_BASE_URL` env var: `http://app:3000` → `http://web:3000`
- `frontend/playwright.config.js` fallback baseURL + comment: same swap
- Hardcoded fallback in 8 `tests/e2e/*.spec.js` files: same swap
- 2 historical planning notes (`customization-branding-plan.md`, `registration-lock-plan.md`): updated for accuracy
- `notes/handover.md`: replaces the "held back" lesson with the actual fix narrative — captures the .app TLD HSTS preload trap so future-you doesn't get fooled by the same misleading symptom

### Why the rename instead of a Chromium flag
The error `net::ERR_SSL_PROTOCOL_ERROR at http://app:3000/...` looked like Chrome 141's auto-HTTPS-upgrade feature. That sent us down a flag-disable rabbit hole (`--unsafely-treat-insecure-origin-as-secure`, `--disable-features=HttpsUpgrades,HttpsFirstBalancedMode,...`, `--test-type`) that all failed.

Real cause: Chromium hardcodes the `.app` gTLD as HSTS-preloaded (Google bought the TLD in 2018 and registered it as HTTPS-only at the registry level). The bare label `app` matches against the preload entry just like `myapp.app` would. **Hardcoded HSTS preloads are a security guarantee, not a feature flag — there is no Chromium command-line argument that disables them.** The supported workaround is to use a hostname outside any preloaded TLD.

`web` is not in any preload list, so the rename gives Chrome 141 nothing to upgrade. Found via the [Playwright issue #15613 thread](https://github.com/microsoft/playwright/issues/15613) and the [Chromium HSTS preload list](https://chromium.googlesource.com/chromium/src/+/main/net/http/transport_security_state_static.json).

## Test plan

- [x] Local Docker test pass: 98 vitest + 103 Playwright green on Playwright 1.59.1 + the renamed `web` service (`docker compose -f docker-compose.test.yml run --rm --build tests`)
- [ ] CI green