### PR TITLE
fix(watcher): close second TOCTOU on writeFileSync (CodeQL #134)

### DIFF
--- a/frontend/server/utils/courseWatcher.js
+++ b/frontend/server/utils/courseWatcher.js
@@ -56,12 +56,21 @@ async function synchronizeCourseThumbnail(courseId, courseFolderName) {
         // mkdirSync with recursive:true is idempotent — no exists-check needed,
         // and dropping the check closes a TOCTOU window between exists and mkdir.
         fs.mkdirSync(courseRoot, { recursive: true });
-        fs.writeFileSync(localThumbnailPath, dbThumbnailData);
+        // 'wx' flag: atomic create-only-if-not-exists. localThumbnailExists
+        // was sampled at function entry (line 33) and there's async DB work
+        // in between, so a concurrent watcher event could have created the
+        // file by now. EEXIST means someone else won the race — leave their
+        // file alone, that's already a thumbnail.
+        fs.writeFileSync(localThumbnailPath, dbThumbnailData, { flag: 'wx' });
         console.log(`[${courseId}] Local thumbnail.png created from DB data at ${localThumbnailPath}`);
       } catch (writeError) {
-        console.error(`[${courseId}] Error writing DB thumbnail to ${localThumbnailPath}:`, writeError);
+        if (writeError.code === 'EEXIST') {
+          console.log(`[${courseId}] Local thumbnail.png appeared concurrently; skipping write.`);
+        } else {
+          console.error(`[${courseId}] Error writing DB thumbnail to ${localThumbnailPath}:`, writeError);
+        }
       }
-    } 
+    }
     // Case 4: DB thumbnail_data is NOT NULL and thumbnail.png exists locally.
     else if (dbThumbnailData && localThumbnailExists) {
       const localFileBuffer = fs.readFileSync(localThumbnailPath); // Read the raw local file


### PR DESCRIPTION
## Summary

Follow-up to [#66](https://github.com/VladoPortos/skillgoblin/pull/66). After fixing the existsSync→mkdirSync race in [#30](https://github.com/VladoPortos/skillgoblin/security/code-scanning/30), CodeQL re-scanned and surfaced [alert #134](https://github.com/VladoPortos/skillgoblin/security/code-scanning/134) — a second TOCTOU on the same code path.

\`localThumbnailExists\` is sampled at the top of \`synchronizeCourseThumbnail\` (line 33), and there's an \`await\`-style DB read between that sample and the \`fs.writeFileSync\` at line 59. A concurrent watcher event could create the local thumbnail between the check and the write, and our write would then clobber it.

Fix: pass \`{ flag: 'wx' }\` to \`writeFileSync\` — atomic create-only-if-not-exists. If a concurrent process won the race we get \`EEXIST\` and leave their file alone (the desired behavior, since their file is already a thumbnail).

## Test plan

- [x] Local Docker test pass: 98 vitest + 103 Playwright green
- [ ] CI green