### PR TITLE
feat(player): CC subtitle toggle wired to PR-A's .vtt endpoint

### DIFF
--- a/frontend/components/video/VideoPlayer.vue
+++ b/frontend/components/video/VideoPlayer.vue
@@ -12,6 +12,14 @@
         @loadedmetadata="onLoadedMetadata"
       >
         <source :key="src" :src="src" type="video/mp4">
+        <track
+          v-if="subtitleSrc"
+          :key="subtitleSrc"
+          kind="subtitles"
+          :src="subtitleSrc"
+          srclang="en"
+          label="English"
+        >
         Your browser does not support the video tag.
       </video>
       <div v-else class="w-full h-full flex items-center justify-center">
@@ -23,6 +31,17 @@
       class="flex flex-wrap items-center gap-3 px-3 py-2 bg-gray-800 text-gray-200 text-sm"
       data-testid="player-controls"
     >
+      <button
+        v-if="subtitleSrc"
+        type="button"
+        data-testid="player-cc-toggle"
+        class="px-2 py-1 rounded border focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400"
+        :class="ccOn ? 'border-primary-400 bg-primary-700/30' : 'border-gray-600 hover:border-gray-400'"
+        :aria-pressed="ccOn"
+        @click="toggleCc"
+      >
+        CC
+      </button>
       <label class="flex items-center gap-1">
         <span class="text-xs uppercase tracking-wide text-gray-400">Speed</span>
         <select
@@ -41,6 +60,8 @@
 <script setup>
 import { ref, watch, onMounted } from 'vue';
 import {
+  getCcDefault,
+  setCcDefault,
   getPlaybackRate,
   setPlaybackRate,
 } from '../../utils/playerPreferences.js';
@@ -49,6 +70,7 @@ const props = defineProps({
   src: { type: String, default: '' },
   autoplay: { type: Boolean, default: false },
   currentTime: { type: Number, default: 0 },
+  subtitleSrc: { type: String, default: '' },
   placeholderText: { type: String, default: 'Select a video to start' },
 });
 
@@ -57,9 +79,8 @@ const emit = defineEmits(['timeupdate', 'ended', 'loadedmetadata']);
 const player = ref(null);
 const ALLOWED_RATES = [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
 const playbackRate = ref(1);
+const ccOn = ref(false);
 
-// Apply the current target time to the player. Safe to call before the
-// element is ready — the watcher handles re-application after `loadedmetadata`.
 function applySeek() {
   if (!player.value) return;
   const t = Number(props.currentTime);
@@ -77,15 +98,39 @@ watch(() => props.src, (newSrc, oldSrc) => {
 
 watch(() => props.currentTime, () => applySeek());
 
+// When subtitleSrc changes (different video, different track), the new
+// <track> element appears; re-apply the CC mode after a tick so the
+// browser has time to register it.
+watch(() => props.subtitleSrc, () => {
+  if (!props.subtitleSrc) return;
+  setTimeout(applyCcMode, 0);
+});
+
 function onLoadedMetadata(event) {
   applySeek();
   if (player.value) {
     player.value.playbackRate = playbackRate.value;
   }
+  applyCcMode();
   if (props.autoplay && player.value) {
     try { player.value.play(); } catch {}
   }
   emit('loadedmetadata', event);
+}
+
+function applyCcMode() {
+  if (!player.value) return;
+  const tracks = player.value.textTracks;
+  if (!tracks) return;
+  for (let i = 0; i < tracks.length; i += 1) {
+    tracks[i].mode = ccOn.value ? 'showing' : 'hidden';
+  }
+}
+
+function toggleCc() {
+  ccOn.value = !ccOn.value;
+  setCcDefault(ccOn.value);
+  applyCcMode();
 }
 
 function onRateChange(event) {
@@ -97,6 +142,7 @@ function onRateChange(event) {
 }
 
 onMounted(() => {
+  ccOn.value = getCcDefault();
   playbackRate.value = getPlaybackRate();
   if (player.value) {
     player.value.playbackRate = playbackRate.value;

--- a/frontend/components/video/VideoPlayer.vue
+++ b/frontend/components/video/VideoPlayer.vue
@@ -80,6 +80,30 @@ const player = ref(null);
 const ALLOWED_RATES = [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
 const playbackRate = ref(1);
 const ccOn = ref(false);
+// Track which textTracks list we've registered the addtrack listener on,
+// so we attach exactly once and detach the same instance on unmount even
+// if the underlying <video> remounts.
+let attachedTextTracks = null;
+
+function attachTrackListener(videoEl) {
+  if (!videoEl || !videoEl.textTracks) return;
+  if (attachedTextTracks === videoEl.textTracks) return;
+  // Detach any previous binding before re-attaching to a new <video>.
+  if (attachedTextTracks && typeof attachedTextTracks.removeEventListener === 'function') {
+    try { attachedTextTracks.removeEventListener('addtrack', onTrackAdded); } catch {}
+  }
+  if (typeof videoEl.textTracks.addEventListener === 'function') {
+    videoEl.textTracks.addEventListener('addtrack', onTrackAdded);
+    attachedTextTracks = videoEl.textTracks;
+  }
+}
+
+function detachTrackListener() {
+  if (attachedTextTracks && typeof attachedTextTracks.removeEventListener === 'function') {
+    try { attachedTextTracks.removeEventListener('addtrack', onTrackAdded); } catch {}
+  }
+  attachedTextTracks = null;
+}
 
 function applySeek() {
   if (!player.value) return;
@@ -95,6 +119,21 @@ watch(() => props.src, (newSrc, oldSrc) => {
   player.value.pause();
   player.value.load();
 }, { immediate: true });
+
+// Attach the addtrack listener once the <video> element actually mounts.
+// The element is gated by `v-if="src"`, so it appears only after the parent
+// supplies a real src — onMounted of this component fires earlier than that
+// on the course-detail page, so onMounted alone misses the binding.
+watch(player, (newPlayer) => {
+  if (newPlayer) {
+    attachTrackListener(newPlayer);
+    // Re-apply current CC mode in case tracks were already attached
+    // synchronously (e.g. when src + subtitleSrc both render in the same tick).
+    applyCcMode();
+  } else {
+    detachTrackListener();
+  }
+});
 
 watch(() => props.currentTime, () => applySeek());
 
@@ -148,20 +187,16 @@ function onRateChange(event) {
 onMounted(() => {
   ccOn.value = getCcDefault();
   playbackRate.value = getPlaybackRate();
+  // The addtrack listener is wired in the player ref watcher above so it
+  // attaches reliably when the <video> element mounts (which can be after
+  // this hook on the course-detail page where src starts empty).
   if (player.value) {
     player.value.playbackRate = playbackRate.value;
-    // Catch tracks that register asynchronously (the addtrack event fires
-    // after the <track> element is parsed and connected to the video).
-    if (player.value.textTracks && typeof player.value.textTracks.addEventListener === 'function') {
-      player.value.textTracks.addEventListener('addtrack', onTrackAdded);
-    }
   }
 });
 
 onBeforeUnmount(() => {
-  if (player.value && player.value.textTracks && typeof player.value.textTracks.removeEventListener === 'function') {
-    player.value.textTracks.removeEventListener('addtrack', onTrackAdded);
-  }
+  detachTrackListener();
 });
 
 defineExpose({

--- a/frontend/components/video/VideoPlayer.vue
+++ b/frontend/components/video/VideoPlayer.vue
@@ -58,7 +58,7 @@
 </template>
 
 <script setup>
-import { ref, watch, onMounted } from 'vue';
+import { ref, watch, onMounted, onBeforeUnmount } from 'vue';
 import {
   getCcDefault,
   setCcDefault,
@@ -98,12 +98,12 @@ watch(() => props.src, (newSrc, oldSrc) => {
 
 watch(() => props.currentTime, () => applySeek());
 
-// When subtitleSrc changes (different video, different track), the new
-// <track> element appears; re-apply the CC mode after a tick so the
-// browser has time to register it.
+// When subtitleSrc changes (different video, different track), re-apply CC
+// mode. Also wire the textTracks `addtrack` event so we don't race the
+// track-element registration: when the new <track> registers asynchronously,
+// onTrackAdded re-applies the user's stored preference.
 watch(() => props.subtitleSrc, () => {
-  if (!props.subtitleSrc) return;
-  setTimeout(applyCcMode, 0);
+  applyCcMode();
 });
 
 function onLoadedMetadata(event) {
@@ -116,6 +116,10 @@ function onLoadedMetadata(event) {
     try { player.value.play(); } catch {}
   }
   emit('loadedmetadata', event);
+}
+
+function onTrackAdded() {
+  applyCcMode();
 }
 
 function applyCcMode() {
@@ -146,6 +150,17 @@ onMounted(() => {
   playbackRate.value = getPlaybackRate();
   if (player.value) {
     player.value.playbackRate = playbackRate.value;
+    // Catch tracks that register asynchronously (the addtrack event fires
+    // after the <track> element is parsed and connected to the video).
+    if (player.value.textTracks && typeof player.value.textTracks.addEventListener === 'function') {
+      player.value.textTracks.addEventListener('addtrack', onTrackAdded);
+    }
+  }
+});
+
+onBeforeUnmount(() => {
+  if (player.value && player.value.textTracks && typeof player.value.textTracks.removeEventListener === 'function') {
+    player.value.textTracks.removeEventListener('addtrack', onTrackAdded);
   }
 });
 

--- a/frontend/pages/courses/[id].vue
+++ b/frontend/pages/courses/[id].vue
@@ -21,6 +21,7 @@
         :src="currentVideoUrl"
         :autoplay="false"
         :current-time="currentTimeForPlayer"
+        :subtitle-src="subtitleSrc"
         @timeupdate="updateProgress"
         @ended="markAsCompleted"
         @loadedmetadata="handleVideoLoaded"
@@ -272,15 +273,30 @@ watch([course, progressReady], () => {
 // Computed values
 const currentVideoUrl = computed(() => {
   if (!currentLesson.value || !currentVideo.value) return '';
-  
+
   // Use the API endpoint for video content
   // Make sure to properly encode the path components
   const courseId = encodeURIComponent(route.params.id);
   const lessonFolder = currentLesson.value.folder ? encodeURIComponent(currentLesson.value.folder) : '';
   const videoFile = encodeURIComponent(currentVideo.value.file);
-  
+
   const lessonPath = lessonFolder ? `/${lessonFolder}` : '';
   return `/api/content/${courseId}${lessonPath}/${videoFile}`;
+});
+
+const subtitleSrc = computed(() => {
+  if (!currentVideo.value || !currentLesson.value) return '';
+  if (!currentVideo.value.subtitle) return '';
+  // PR-A's server emits the .vtt filename in `subtitle` (it converts the
+  // sibling .srt on demand). We just URL-encode it and return the full
+  // /api/content/... path.
+  const courseId = encodeURIComponent(route.params.id);
+  const lessonFolder = currentLesson.value.folder
+    ? encodeURIComponent(currentLesson.value.folder)
+    : '';
+  const subtitleFilename = String(currentVideo.value.subtitle);
+  const lessonPath = lessonFolder ? `/${lessonFolder}` : '';
+  return `/api/content/${courseId}${lessonPath}/${encodeURIComponent(subtitleFilename)}`;
 });
 
 const totalVideos = computed(() => {

--- a/frontend/tests/e2e/player-cc.spec.js
+++ b/frontend/tests/e2e/player-cc.spec.js
@@ -35,12 +35,29 @@ async function rescanAndWait(request) {
   throw new Error('Rescan did not complete in time');
 }
 
-async function openFirstCourse(page) {
-  await page.goto('/courses');
+// Pull the course list and find a course whose first video has NO `subtitle`
+// field. Returns the course id. Throws if every fixture course has subtitles
+// (in which case this test would be vacuous and a fixture without an .srt
+// sibling needs to be added).
+async function findCourseWithoutSubtitle(request) {
+  const r = await request.get('/api/courses?limit=20');
+  expect(r.ok()).toBeTruthy();
+  const body = await r.json();
+  expect(Array.isArray(body.items) && body.items.length > 0).toBe(true);
+  for (const item of body.items) {
+    const detail = await request.get(`/api/courses/${item.id}`);
+    const course = await detail.json();
+    const firstVideo = course?.lessons?.[0]?.videos?.[0];
+    if (firstVideo && !firstVideo.subtitle) {
+      return course.id;
+    }
+  }
+  throw new Error('No fixture course has a video without a subtitle sidecar.');
+}
+
+async function openCourseDetail(page, courseId) {
+  await page.goto(`/courses/${encodeURIComponent(courseId)}`);
   await page.waitForLoadState('networkidle');
-  const firstCard = page.locator('main h3').first();
-  await firstCard.click();
-  await page.waitForURL(/\/courses\/[^/]+/);
   await page.waitForSelector('[data-testid=player-speed]', { timeout: 5_000 });
 }
 
@@ -50,10 +67,11 @@ test.describe('player CC toggle', () => {
     await rescanAndWait(request);
   });
 
-  test('CC button is hidden when no subtitle sidecar exists', async ({ page, request }) => {
+  test('CC button is hidden when the selected video has no subtitle sidecar', async ({ page, request }) => {
     await loginAdmin(request);
     await attachAuthCookie(page, request);
-    await openFirstCourse(page);
+    const courseId = await findCourseWithoutSubtitle(request);
+    await openCourseDetail(page, courseId);
     await expect(page.locator('[data-testid=player-cc-toggle]')).toHaveCount(0);
   });
 });

--- a/frontend/tests/e2e/player-cc.spec.js
+++ b/frontend/tests/e2e/player-cc.spec.js
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+
+const ADMIN_NAME = process.env.PW_ADMIN_NAME || 'root';
+const ADMIN_PASSWORD = process.env.PW_ADMIN_PASSWORD || 'TestAdminPass!';
+
+async function loginAdmin(request) {
+  const usersRes = await request.get('/api/users');
+  expect(usersRes.ok()).toBeTruthy();
+  const users = await usersRes.json();
+  const admin = users.find((u) => u.name === ADMIN_NAME);
+  expect(admin, `expected admin "${ADMIN_NAME}" in /api/users`).toBeTruthy();
+  const r = await request.post('/api/users/auth', {
+    data: { userId: admin.id, password: ADMIN_PASSWORD },
+  });
+  expect(r.ok()).toBeTruthy();
+  const body = await r.json();
+  expect(body.success).toBe(true);
+  return admin;
+}
+
+async function attachAuthCookie(page, request) {
+  const cookies = await request.storageState();
+  await page.context().addCookies(cookies.cookies);
+}
+
+async function rescanAndWait(request) {
+  const rescan = await request.post('/api/courses/rescan', { data: { preserveMetadata: true } });
+  expect(rescan.ok()).toBeTruthy();
+  for (let i = 0; i < 30; i += 1) {
+    const s = await request.get('/api/status/scan');
+    const body = await s.json();
+    if (body.complete) return;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error('Rescan did not complete in time');
+}
+
+async function openFirstCourse(page) {
+  await page.goto('/courses');
+  await page.waitForLoadState('networkidle');
+  const firstCard = page.locator('main h3').first();
+  await firstCard.click();
+  await page.waitForURL(/\/courses\/[^/]+/);
+  await page.waitForSelector('[data-testid=player-speed]', { timeout: 5_000 });
+}
+
+test.describe('player CC toggle', () => {
+  test.beforeAll(async ({ request }) => {
+    await loginAdmin(request);
+    await rescanAndWait(request);
+  });
+
+  test('CC button is hidden when no subtitle sidecar exists', async ({ page, request }) => {
+    await loginAdmin(request);
+    await attachAuthCookie(page, request);
+    await openFirstCourse(page);
+    await expect(page.locator('[data-testid=player-cc-toggle]')).toHaveCount(0);
+  });
+});

--- a/frontend/tests/unit/playerPreferences.test.js
+++ b/frontend/tests/unit/playerPreferences.test.js
@@ -1,13 +1,32 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
+  CC_KEY,
   RATE_KEY,
+  getCcDefault,
+  setCcDefault,
   getPlaybackRate,
   setPlaybackRate,
 } from '../../utils/playerPreferences.js';
 
 beforeEach(() => {
   window.localStorage.clear();
+});
+
+describe('CC default', () => {
+  it('returns false when key is missing', () => {
+    expect(getCcDefault()).toBe(false);
+  });
+  it('round-trips a true value', () => {
+    setCcDefault(true);
+    expect(window.localStorage.getItem(CC_KEY)).toBe('1');
+    expect(getCcDefault()).toBe(true);
+  });
+  it('round-trips a false value', () => {
+    setCcDefault(false);
+    expect(window.localStorage.getItem(CC_KEY)).toBe('0');
+    expect(getCcDefault()).toBe(false);
+  });
 });
 
 describe('playback rate', () => {

--- a/frontend/utils/playerPreferences.js
+++ b/frontend/utils/playerPreferences.js
@@ -1,3 +1,4 @@
+export const CC_KEY = 'skillgoblin:cc:default';
 export const RATE_KEY = 'skillgoblin:playbackRate';
 
 const ALLOWED_RATES = new Set([0.5, 0.75, 1, 1.25, 1.5, 1.75, 2]);
@@ -9,6 +10,18 @@ function safeStorage() {
   } catch {
     return null;
   }
+}
+
+export function getCcDefault() {
+  const s = safeStorage();
+  if (!s) return false;
+  return s.getItem(CC_KEY) === '1';
+}
+
+export function setCcDefault(value) {
+  const s = safeStorage();
+  if (!s) return;
+  s.setItem(CC_KEY, value ? '1' : '0');
 }
 
 export function getPlaybackRate() {


### PR DESCRIPTION
## Summary

Follow-up to PR-C (#74). Wires the closed-caption toggle that was deferred when PR-A's `subtitle` field wasn't yet on main. Now that #71 is merged, this is a small additive change:

- Re-adds CC localStorage helpers (`getCcDefault` / `setCcDefault`) to `playerPreferences.js`. Speed memory is unchanged.
- `VideoPlayer.vue` exposes a `subtitleSrc` prop. When set, renders an inline `<track kind="subtitles" srclang="en">` and a CC toggle button before the speed dropdown.
- `pages/courses/[id].vue` computes `subtitleSrc` from `currentVideo.subtitle` (the field PR-A's server emits when an `.srt` sidecar is detected) and passes it down. The server already serves `.vtt` on demand by converting the sibling `.srt`, so this is just URL plumbing on the client.
- CC state persists per-browser via `localStorage` and is re-applied on every track addition.

## Track-load race fix

A naive `<track>` insertion races the parent's `loadedmetadata` and the watcher on `subtitleSrc` — by the time those fire, `video.textTracks` may still be empty. The PR handles this by:

1. Watching the player template ref. When the `<video>` element mounts (it's `v-if="src"`, so it only appears once a real src is set), we attach an `addtrack` listener on `video.textTracks`.
2. The `addtrack` listener re-runs `applyCcMode()`, which sets every track's `mode` to `showing` or `hidden` based on the user's stored preference.
3. The listener is detached cleanly on unmount and re-attached if the `<video>` remounts (handled by the ref watcher's else branch).

## Test plan

- [x] Vitest unit suite green: 19 files / 172 tests (added 3: CC default helpers in `playerPreferences.test.js`)
- [x] Playwright e2e: `player-cc.spec.js` asserts the CC button is hidden when the selected video has no `.srt` sidecar. Test queries `/api/courses` first to find a fixture course with a subtitle-less first video, so it's independent of fixture order.
- [x] Codex security review iterated 3 times; all 3 findings fixed; final pass returned CLEAN
  - 1 MEDIUM: track-load race not handled by setTimeout fallback → `1f64453` (addtrack listener)
  - 1 LOW: e2e fixture-order dependent → `1f64453` (API-driven course selection)
  - 1 MEDIUM: addtrack listener missed because `<video>` is v-if'd off until src loads → `b771cb8` (player ref watcher)

## Manual verification

To see the CC button live, drop an `.srt` next to any video in `data/content/<Course>/<Lesson>/`:

```
data/content/Sample Course/Lesson 1/01-intro.mp4
data/content/Sample Course/Lesson 1/01-intro.srt   <-- add this
```

Trigger a rescan from the avatar dropdown. Open the course. The video player now shows a **CC** button before the speed dropdown. Click it to toggle captions; reload the page — the CC state persists.

When no `.srt` exists, the CC button is not rendered.