### PR TITLE
fix(player+ui): aligned sort, clickable header, click-to-resume, styled start-from-beginning

### DIFF
--- a/frontend/components/course/CourseHeader.vue
+++ b/frontend/components/course/CourseHeader.vue
@@ -7,10 +7,10 @@
             <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
           </svg>
         </button>
-        <div class="flex items-center mr-4">
+        <NuxtLink to="/courses" class="flex items-center mr-4 hover:opacity-80 transition-opacity" :aria-label="`${branding.name} home`">
           <img :src="'/api/logo'" :alt="`${branding.name} Logo`" class="w-6 h-6 mr-2 hidden sm:block" />
           <span class="text-sm font-medium text-gray-900 dark:text-white hidden sm:block">{{ branding.name }}</span>
-        </div>
+        </NuxtLink>
         <h1 class="text-xl font-bold text-gray-900 dark:text-white truncate max-w-[140px] sm:max-w-xs md:max-w-md">{{ course?.title || 'Loading...' }}</h1>
         <!-- Course Progress Indicator -->
         <div v-if="course && totalVideos > 0" class="ml-4 flex items-center">

--- a/frontend/components/course/CourseHeader.vue
+++ b/frontend/components/course/CourseHeader.vue
@@ -7,9 +7,9 @@
             <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
           </svg>
         </button>
-        <NuxtLink to="/courses" class="flex items-center mr-4 hover:opacity-80 transition-opacity" :aria-label="`${branding.name} home`">
-          <img :src="'/api/logo'" :alt="`${branding.name} Logo`" class="w-6 h-6 mr-2 hidden sm:block" />
-          <span class="text-sm font-medium text-gray-900 dark:text-white hidden sm:block">{{ branding.name }}</span>
+        <NuxtLink to="/courses" class="hidden sm:flex items-center mr-4 hover:opacity-80 transition-opacity" :aria-label="`${branding.name} home`">
+          <img :src="'/api/logo'" :alt="`${branding.name} Logo`" class="w-6 h-6 mr-2" />
+          <span class="text-sm font-medium text-gray-900 dark:text-white">{{ branding.name }}</span>
         </NuxtLink>
         <h1 class="text-xl font-bold text-gray-900 dark:text-white truncate max-w-[140px] sm:max-w-xs md:max-w-md">{{ course?.title || 'Loading...' }}</h1>
         <!-- Course Progress Indicator -->

--- a/frontend/components/ui/SearchBar.vue
+++ b/frontend/components/ui/SearchBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative mb-6">
+  <div class="relative">
     <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
       <svg class="h-5 w-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
         <path fill-rule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clip-rule="evenodd" />

--- a/frontend/components/video/VideoPlayer.vue
+++ b/frontend/components/video/VideoPlayer.vue
@@ -53,6 +53,18 @@
           <option v-for="r in ALLOWED_RATES" :key="r" :value="r">{{ r }}×</option>
         </select>
       </label>
+      <button
+        type="button"
+        data-testid="start-from-beginning"
+        class="ml-auto inline-flex items-center gap-1 px-2 py-1 rounded border border-gray-600 hover:border-gray-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 text-xs"
+        title="Start from the first lesson"
+        @click="$emit('start-from-beginning')"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M11 19l-7-7 7-7m8 14l-7-7 7-7" />
+        </svg>
+        Start from beginning
+      </button>
     </div>
   </div>
 </template>
@@ -74,7 +86,7 @@ const props = defineProps({
   placeholderText: { type: String, default: 'Select a video to start' },
 });
 
-const emit = defineEmits(['timeupdate', 'ended', 'loadedmetadata']);
+const emit = defineEmits(['timeupdate', 'ended', 'loadedmetadata', 'start-from-beginning']);
 
 const player = ref(null);
 const ALLOWED_RATES = [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];

--- a/frontend/components/video/VideoPlayer.vue
+++ b/frontend/components/video/VideoPlayer.vue
@@ -217,5 +217,10 @@ defineExpose({
   getCurrentTime() { return player.value ? player.value.currentTime : 0; },
   getDuration() { return player.value ? player.value.duration : 0; },
   setCurrentTime(time) { if (player.value) player.value.currentTime = time; },
+  // Used by the parent to reject stale loadedmetadata events: if a second
+  // playVideo lands before the first src finished loading, the now-superseded
+  // metadata event would otherwise clear the transition gate against the
+  // wrong duration. The parent compares this against the src it asked for.
+  getCurrentSrc() { return player.value ? player.value.currentSrc : ''; },
 });
 </script>

--- a/frontend/components/video/VideoPlayer.vue
+++ b/frontend/components/video/VideoPlayer.vue
@@ -57,7 +57,7 @@
         type="button"
         data-testid="start-from-beginning"
         class="ml-auto inline-flex items-center gap-1 px-2 py-1 rounded border border-gray-600 hover:border-gray-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 text-xs"
-        title="Start from the first lesson"
+        title="Restart this video from the beginning"
         @click="$emit('start-from-beginning')"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">

--- a/frontend/pages/courses/[id].vue
+++ b/frontend/pages/courses/[id].vue
@@ -63,36 +63,34 @@
               v-for="(video, index) in lesson.videos"
               :key="`${lesson.id}-${index}`"
               :data-testid="`lesson-video-${lesson.id}-${index}`"
-              class="py-2 px-4 hover:bg-gray-100 dark:hover:bg-gray-600 rounded mb-2"
+              class="py-2 px-4 hover:bg-gray-100 dark:hover:bg-gray-600 rounded mb-2 cursor-pointer"
+              @click="playVideo(lesson, video)"
             >
               <div class="flex items-center">
-                <div 
-                  class="mr-3 shrink-0 cursor-pointer" 
-                  @click="playVideo(lesson, video)"
-                >
+                <div class="mr-3 shrink-0">
                   <div v-if="completedVideos[`${lesson.id}-${index}`]" class="w-5 h-5 bg-green-500 dark:bg-green-400 rounded-full flex items-center justify-center">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="3" d="M5 13l4 4L19 7" />
                     </svg>
                   </div>
                   <div v-else-if="videoProgress[`${lesson.id}-${index}`]" class="w-5 h-5 rounded-full border-2 border-blue-500 dark:border-blue-400 relative">
-                    <div class="absolute inset-0.5 bg-blue-500 dark:bg-blue-400 rounded-full" :style="{ 
-                      clipPath: `polygon(0 0, 100% 0, 100% ${videoProgress[`${lesson.id}-${index}`]}%, 0 ${videoProgress[`${lesson.id}-${index}`]}%)` 
+                    <div class="absolute inset-0.5 bg-blue-500 dark:bg-blue-400 rounded-full" :style="{
+                      clipPath: `polygon(0 0, 100% 0, 100% ${videoProgress[`${lesson.id}-${index}`]}%, 0 ${videoProgress[`${lesson.id}-${index}`]}%)`
                     }"></div>
                   </div>
                   <div v-else class="w-5 h-5 rounded-full border-2 border-gray-400 dark:border-gray-500"></div>
                 </div>
-                <div 
-                  class="flex-grow cursor-pointer"
-                  @click="playVideo(lesson, video)"
-                >
+                <div class="flex-grow">
                   {{ video.title }}
                 </div>
-                <VideoControlButtons 
-                  :is-completed="completedVideos[`${lesson.id}-${index}`]" 
-                  @toggle-completion="toggleVideoCompletionById(`${lesson.id}-${index}`)" 
-                  @reset-progress="resetVideoProgressById(`${lesson.id}-${index}`)"
-                />
+                <!-- Action buttons must not bubble into the row's playVideo handler. -->
+                <div @click.stop>
+                  <VideoControlButtons
+                    :is-completed="completedVideos[`${lesson.id}-${index}`]"
+                    @toggle-completion="toggleVideoCompletionById(`${lesson.id}-${index}`)"
+                    @reset-progress="resetVideoProgressById(`${lesson.id}-${index}`)"
+                  />
+                </div>
               </div>
             </div>
           </div>
@@ -177,6 +175,17 @@ const progressReady = ref(false);
 // bypassing any saved partial progress. Used by "Start from beginning"
 // when the new src differs from the previous one.
 const forceFromZero = ref(false);
+// Gate that suppresses updateProgress writes between a click on a new
+// video (in playVideo) and the matching loadedmetadata for that video
+// (handleVideoLoaded). Without this gate, a stray timeupdate event during
+// the transition window — when currentVideoId already points at the new
+// video but the <video> element still has the previous src loaded (or is
+// being reset by .load()) — calls updateProgress with currentTime=0/duration
+// of the wrong asset, writes 0 to videoProgress[currentVideoId], and
+// saveProgress persists that 0 to the backend. Subsequent handleVideoLoaded
+// then reads 0 and seeks to 0, so the user sees the video restart from
+// scratch and their saved position is gone.
+const transitioning = ref(false);
 
 // Fetch course data and user progress
 onMounted(async () => {
@@ -344,6 +353,10 @@ function playVideo(lesson, video, autoPlay = true) {
 
   // Only reset and play if we're changing videos
   if (previousVideoId !== currentVideoId.value) {
+    // Suppress updateProgress writes until handleVideoLoaded confirms the
+    // new src is loaded — see the `transitioning` ref declaration for the
+    // full rationale.
+    transitioning.value = true;
     // Reset the seek prop to 0 BEFORE the new src loads. handleVideoLoaded
     // will recompute the actual seek (from saved progress) once duration is
     // known and reassign currentTimeForPlayer. Without this reset, two videos
@@ -371,15 +384,16 @@ function playVideo(lesson, video, autoPlay = true) {
 
 function updateProgress(event) {
   if (!videoPlayer.value || !currentVideoId.value) return;
-  
-  // Get time from the video element via the exposed method
+  // Don't write progress while the player is mid-transition between videos
+  // — currentVideoId already points at the new video but the <video>
+  // element may still be on the previous src or in a load() reset.
+  if (transitioning.value) return;
   const currentTime = videoPlayer.value.getCurrentTime();
   const duration = videoPlayer.value.getDuration();
+  // Guard against NaN/0 duration leaking into a NaN progress write.
+  if (!Number.isFinite(duration) || duration <= 0) return;
   const progress = (currentTime / duration) * 100;
-  
   videoProgress.value[currentVideoId.value] = progress;
-  
-  // Save progress to database
   saveProgress();
 }
 
@@ -389,6 +403,9 @@ function handleVideoLoaded() {
   if (!videoPlayer.value || !currentVideoId.value) return;
   const duration = videoPlayer.value.getDuration();
   if (!Number.isFinite(duration) || duration <= 0) return;
+  // Duration is now valid for the loaded src — reopen the updateProgress
+  // gate so playback writes start landing on the new video.
+  transitioning.value = false;
   // One-shot override from "Start from beginning": the caller wants 0
   // regardless of saved progress.
   if (forceFromZero.value) {
@@ -512,27 +529,14 @@ async function saveProgress() {
 }
 
 function startFromBeginning() {
-  if (!course.value?.lessons?.length) return;
-  const firstLesson = course.value.lessons[0];
-  if (!firstLesson?.videos?.length) return;
-  const firstVideo = firstLesson.videos[0];
-  // Tell handleVideoLoaded to ignore any saved progress for this seek
-  // — applies to BOTH the same-video case (no src change, no loadedmetadata)
-  // and the cross-video case (new src triggers loadedmetadata which would
-  // otherwise reapply saved progress).
+  // Rewind the CURRENT video to 0. Same src → no reload, no loadedmetadata,
+  // so handleVideoLoaded won't re-apply saved progress on its own. Set
+  // forceFromZero as a guard in case the seek pipeline does refire, then
+  // seek directly via the player's exposed method.
+  if (!videoPlayer.value || !currentVideoId.value) return;
   forceFromZero.value = true;
-  Object.keys(expandedLessons.value).forEach((id) => {
-    expandedLessons.value[id] = false;
-  });
-  expandedLessons.value[firstLesson.id] = true;
-  currentLesson.value = firstLesson;
-  currentVideo.value = firstVideo;
-  currentVideoId.value = `${firstLesson.id}-0`;
   currentTimeForPlayer.value = 0;
-  // If the first video was already the selected one, the prop didn't change
-  // and the watcher in VideoPlayer won't seek. Force it explicitly. The
-  // forceFromZero flag is consumed in handleVideoLoaded if a new src does load.
-  if (videoPlayer.value && typeof videoPlayer.value.setCurrentTime === 'function') {
+  if (typeof videoPlayer.value.setCurrentTime === 'function') {
     videoPlayer.value.setCurrentTime(0);
   }
 }

--- a/frontend/pages/courses/[id].vue
+++ b/frontend/pages/courses/[id].vue
@@ -171,10 +171,13 @@ const showFilesModal = ref(false);
 // progress and the early-exit-on-currentVideo guard prevents the later
 // progress-loaded trigger from correcting it.
 const progressReady = ref(false);
-// One-shot flag: when set, the next handleVideoLoaded forces seek to 0,
-// bypassing any saved partial progress. Used by "Start from beginning"
-// when the new src differs from the previous one.
-const forceFromZero = ref(false);
+// Scoped one-shot flag: when set to a videoId, the next handleVideoLoaded
+// for THAT video id forces seek to 0, bypassing any saved partial progress.
+// Holding the flag against a specific videoId (instead of a global boolean)
+// matters for the same-src "Start from beginning" rewind case: no
+// loadedmetadata fires there, so a global flag would persist and force the
+// user's NEXT video selection to start at 0 too — wiping its saved resume.
+const forceFromZeroFor = ref(null);
 // Gate that suppresses updateProgress writes between a click on a new
 // video (in playVideo) and the matching loadedmetadata for that video
 // (handleVideoLoaded). Without this gate, a stray timeupdate event during
@@ -186,6 +189,12 @@ const forceFromZero = ref(false);
 // then reads 0 and seeks to 0, so the user sees the video restart from
 // scratch and their saved position is gone.
 const transitioning = ref(false);
+// The src URL the most recent playVideo asked the player to load. Used by
+// handleVideoLoaded to reject a stale loadedmetadata event from a previous
+// load() that the user has since superseded by clicking another video — if
+// we acted on it we'd clear the gate and apply seek math against the wrong
+// element duration.
+const expectedSrc = ref(null);
 
 // Fetch course data and user progress
 onMounted(async () => {
@@ -357,6 +366,10 @@ function playVideo(lesson, video, autoPlay = true) {
     // new src is loaded — see the `transitioning` ref declaration for the
     // full rationale.
     transitioning.value = true;
+    // Stamp the src we're asking the player to load. handleVideoLoaded
+    // checks this against the element's currentSrc and ignores stale
+    // loadedmetadata events from a load() the user has since superseded.
+    expectedSrc.value = currentVideoUrl.value;
     // Reset the seek prop to 0 BEFORE the new src loads. handleVideoLoaded
     // will recompute the actual seek (from saved progress) once duration is
     // known and reassign currentTimeForPlayer. Without this reset, two videos
@@ -401,16 +414,26 @@ function updateProgress(event) {
 
 function handleVideoLoaded() {
   if (!videoPlayer.value || !currentVideoId.value) return;
+  // Reject stale loadedmetadata events: if expectedSrc was set by a more
+  // recent playVideo and the element's currentSrc is something else, this
+  // event is from a load() the user has since superseded. Acting on it
+  // would clear the gate and apply seek math against the wrong duration.
+  if (expectedSrc.value && typeof videoPlayer.value.getCurrentSrc === 'function') {
+    const loadedSrc = videoPlayer.value.getCurrentSrc() || '';
+    if (loadedSrc && !loadedSrc.endsWith(expectedSrc.value)) return;
+  }
   const duration = videoPlayer.value.getDuration();
   if (!Number.isFinite(duration) || duration <= 0) return;
   // Duration is now valid for the loaded src — reopen the updateProgress
-  // gate so playback writes start landing on the new video.
+  // gate so playback writes start landing on the new video, and clear the
+  // src expectation now that this load is settled.
   transitioning.value = false;
+  expectedSrc.value = null;
   // One-shot override from "Start from beginning": the caller wants 0
-  // regardless of saved progress.
-  if (forceFromZero.value) {
+  // regardless of saved progress, but ONLY for the video they targeted.
+  if (forceFromZeroFor.value === currentVideoId.value) {
     currentTimeForPlayer.value = 0;
-    forceFromZero.value = false;
+    forceFromZeroFor.value = null;
     return;
   }
   // A completed video should always reopen at 0 even if a stale partial-progress
@@ -530,11 +553,13 @@ async function saveProgress() {
 
 function startFromBeginning() {
   // Rewind the CURRENT video to 0. Same src → no reload, no loadedmetadata,
-  // so handleVideoLoaded won't re-apply saved progress on its own. Set
-  // forceFromZero as a guard in case the seek pipeline does refire, then
-  // seek directly via the player's exposed method.
+  // so handleVideoLoaded won't re-apply saved progress on its own. Scope
+  // the forceFromZero token to THIS videoId — that way, if a loadedmetadata
+  // happens to fire for this video, it will honor the rewind, but if the
+  // user clicks a different video before that, the new video's saved resume
+  // is not affected.
   if (!videoPlayer.value || !currentVideoId.value) return;
-  forceFromZero.value = true;
+  forceFromZeroFor.value = currentVideoId.value;
   currentTimeForPlayer.value = 0;
   if (typeof videoPlayer.value.setCurrentTime === 'function') {
     videoPlayer.value.setCurrentTime(0);

--- a/frontend/pages/courses/[id].vue
+++ b/frontend/pages/courses/[id].vue
@@ -354,6 +354,8 @@ function toggleLesson(lessonId) {
 function playVideo(lesson, video, autoPlay = true) {
   // Store previous video info to check if we're changing videos
   const previousVideoId = currentVideoId.value;
+  // Snapshot the URL BEFORE we mutate the refs that drive the computed.
+  const previousVideoUrl = currentVideoUrl.value;
 
   // Update current video information
   currentLesson.value = lesson;
@@ -367,14 +369,7 @@ function playVideo(lesson, video, autoPlay = true) {
     // later click-back to that video would honor a stale token and clobber
     // the newer saved resume.
     forceFromZeroFor.value = null;
-    // Suppress updateProgress writes until handleVideoLoaded confirms the
-    // new src is loaded — see the `transitioning` ref declaration for the
-    // full rationale.
-    transitioning.value = true;
-    // Stamp the src we're asking the player to load. handleVideoLoaded
-    // checks this against the element's currentSrc and ignores stale
-    // loadedmetadata events from a load() the user has since superseded.
-    expectedSrc.value = currentVideoUrl.value;
+    const newVideoUrl = currentVideoUrl.value;
     // Reset the seek prop to 0 BEFORE the new src loads. handleVideoLoaded
     // will recompute the actual seek (from saved progress) once duration is
     // known and reassign currentTimeForPlayer. Without this reset, two videos
@@ -384,6 +379,23 @@ function playVideo(lesson, video, autoPlay = true) {
     // freshly-loaded element would never seek and the user would see the
     // video start from 0 instead of resuming.
     currentTimeForPlayer.value = 0;
+    if (newVideoUrl !== previousVideoUrl) {
+      // Real src change incoming — VideoPlayer's src watcher will pause()
+      // and load(). Suppress updateProgress and markAsCompleted until
+      // handleVideoLoaded confirms the new src is loaded; stamp expectedSrc
+      // so handleVideoLoaded ignores stale loadedmetadata events from a
+      // load() the user has since superseded.
+      transitioning.value = true;
+      expectedSrc.value = newVideoUrl;
+    } else {
+      // Same media URL: VideoPlayer's src watcher bails (newSrc === oldSrc),
+      // no load() fires, and no loadedmetadata follows. Arming the gate here
+      // would leave it stuck forever and permanently disable progress
+      // tracking. Apply the seek synchronously instead — the element is
+      // already loaded so duration is valid and handleVideoLoaded will run
+      // its normal saved-progress flow against the new currentVideoId.
+      handleVideoLoaded();
+    }
     nextTick(() => {
       if (videoPlayer.value) {
         // Our component handles the video source change via props

--- a/frontend/pages/courses/[id].vue
+++ b/frontend/pages/courses/[id].vue
@@ -68,9 +68,10 @@
           
           <!-- Video List -->
           <div v-if="expandedLessons[lesson.id]" class="bg-gray-50 dark:bg-gray-700 p-4">
-            <div 
-              v-for="(video, index) in lesson.videos" 
+            <div
+              v-for="(video, index) in lesson.videos"
               :key="`${lesson.id}-${index}`"
+              :data-testid="`lesson-video-${lesson.id}-${index}`"
               class="py-2 px-4 hover:bg-gray-100 dark:hover:bg-gray-600 rounded mb-2"
             >
               <div class="flex items-center">
@@ -344,19 +345,28 @@ function toggleLesson(lessonId) {
 function playVideo(lesson, video, autoPlay = true) {
   // Store previous video info to check if we're changing videos
   const previousVideoId = currentVideoId.value;
-  
+
   // Update current video information
   currentLesson.value = lesson;
   currentVideo.value = video;
   currentVideoId.value = `${lesson.id}-${lesson.videos.indexOf(video)}`;
-  
+
   // Only reset and play if we're changing videos
   if (previousVideoId !== currentVideoId.value) {
+    // Reset the seek prop to 0 BEFORE the new src loads. handleVideoLoaded
+    // will recompute the actual seek (from saved progress) once duration is
+    // known and reassign currentTimeForPlayer. Without this reset, two videos
+    // whose computed seek targets happen to coincide (or the previous video's
+    // seek value being reused) would leave currentTimeForPlayer unchanged —
+    // VideoPlayer's currentTime watcher only fires on value change, so the
+    // freshly-loaded element would never seek and the user would see the
+    // video start from 0 instead of resuming.
+    currentTimeForPlayer.value = 0;
     nextTick(() => {
       if (videoPlayer.value) {
         // Our component handles the video source change via props
         // and will auto-set time via loadedmetadata event
-        
+
         // Auto-play if requested
         if (autoPlay) {
           setTimeout(() => {

--- a/frontend/pages/courses/[id].vue
+++ b/frontend/pages/courses/[id].vue
@@ -25,17 +25,8 @@
         @timeupdate="updateProgress"
         @ended="markAsCompleted"
         @loadedmetadata="handleVideoLoaded"
+        @start-from-beginning="startFromBeginning"
       />
-      <div class="text-xs text-gray-500 dark:text-gray-400 mb-3 text-right">
-        <button
-          type="button"
-          data-testid="start-from-beginning"
-          class="underline hover:text-gray-700 dark:hover:text-gray-200"
-          @click="startFromBeginning"
-        >
-          Start from beginning
-        </button>
-      </div>
 
       <!-- Video Info -->
       <VideoInfo 

--- a/frontend/pages/courses/[id].vue
+++ b/frontend/pages/courses/[id].vue
@@ -395,6 +395,17 @@ function playVideo(lesson, video, autoPlay = true) {
       // already loaded so duration is valid and handleVideoLoaded will run
       // its normal saved-progress flow against the new currentVideoId.
       handleVideoLoaded();
+      // currentTimeForPlayer was set to 0 above and handleVideoLoaded may
+      // have set it back to the same value the prop already had (common
+      // when the new video has no saved progress, or its computed target
+      // coincides with the previous prop value). Vue coalesces same-tick
+      // writes and only fires the watcher on a value change vs. the
+      // previously-flushed value, so the parent's seek pipeline can no-op
+      // — leaving the reused element at the previous video's playback
+      // position. Force the seek out-of-band to make this branch robust.
+      if (typeof videoPlayer.value.setCurrentTime === 'function') {
+        videoPlayer.value.setCurrentTime(currentTimeForPlayer.value);
+      }
     }
     nextTick(() => {
       if (videoPlayer.value) {

--- a/frontend/pages/courses/[id].vue
+++ b/frontend/pages/courses/[id].vue
@@ -362,6 +362,11 @@ function playVideo(lesson, video, autoPlay = true) {
 
   // Only reset and play if we're changing videos
   if (previousVideoId !== currentVideoId.value) {
+    // Switching videos invalidates any pending "rewind to 0 if loadedmetadata
+    // fires" override that startFromBeginning may have stamped — otherwise a
+    // later click-back to that video would honor a stale token and clobber
+    // the newer saved resume.
+    forceFromZeroFor.value = null;
     // Suppress updateProgress writes until handleVideoLoaded confirms the
     // new src is loaded — see the `transitioning` ref declaration for the
     // full rationale.
@@ -452,13 +457,13 @@ function handleVideoLoaded() {
 
 function markAsCompleted() {
   if (!currentVideoId.value) return;
-  
+  // A stale `ended` event fired during a video transition (the user
+  // clicked another row before the previous video's ended event drained
+  // from the queue) would otherwise mark the newly-selected video as
+  // completed and auto-advance past it. Same gate as updateProgress.
+  if (transitioning.value) return;
   completedVideos.value[currentVideoId.value] = true;
-  
-  // Save progress to database
   saveProgress();
-  
-  // Auto-play next video if available
   playNextVideo();
 }
 

--- a/frontend/pages/courses/index.vue
+++ b/frontend/pages/courses/index.vue
@@ -2,10 +2,10 @@
   <div class="min-h-screen bg-gray-50 dark:bg-gray-900">
     <header class="bg-white dark:bg-gray-800 shadow-sm">
       <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8 flex justify-between items-center">
-        <div class="flex items-center">
+        <NuxtLink to="/courses" class="flex items-center hover:opacity-80 transition-opacity" :aria-label="`${branding.name} home`">
           <img :src="'/api/logo'" :alt="`${branding.name} Logo`" class="w-10 h-10 mr-3" />
           <h1 class="text-3xl font-bold text-gray-900 dark:text-white">{{ branding.name }}</h1>
-        </div>
+        </NuxtLink>
         <div class="flex items-center space-x-4">
           <UserProfile
             :user="userObject"

--- a/frontend/pages/courses/index.vue
+++ b/frontend/pages/courses/index.vue
@@ -169,7 +169,7 @@
             />
             
             <!-- Search + sort -->
-            <div class="flex flex-col sm:flex-row sm:items-center gap-3 mt-3">
+            <div class="flex flex-col sm:flex-row sm:items-center gap-3 mt-3 mb-6">
               <div class="flex-1">
                 <SearchBar
                   v-model:search-query="searchQuery"
@@ -181,7 +181,7 @@
                 <select
                   data-testid="course-sort"
                   v-model="sortMode"
-                  class="rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-white text-sm px-2 py-1"
+                  class="block px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md leading-5 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:outline-none focus:ring-1 focus:ring-primary-500 focus:border-primary-500 sm:text-sm"
                 >
                   <option value="title">Title (A–Z)</option>
                   <option value="newest">Newest first</option>

--- a/frontend/tests/e2e/player-resume.spec.js
+++ b/frontend/tests/e2e/player-resume.spec.js
@@ -72,32 +72,32 @@ test.describe('player resume + smart open', () => {
     await expect(page.locator('[data-testid=player-speed]')).toBeVisible({ timeout: 5_000 });
   });
 
-  test('clicking a partially-watched video resumes from saved position', async ({ page, request }) => {
-    // Regression for the click-to-resume bug. VideoPlayer's currentTime
-    // watcher only fires on value-change (Vue ref semantics), so when
-    // handleVideoLoaded reassigns currentTimeForPlayer to the SAME numeric
-    // value as before — easy to hit with two videos at the same saved-progress
-    // percentage and same duration — no seek lands on the freshly-loaded
-    // element. The fix resets currentTimeForPlayer to 0 inside playVideo on
-    // video change so the parent watcher's next write is always a value
-    // transition.
+  test('clicking another video and back preserves saved progress (regression)', async ({ page, request }) => {
+    // Reproduces the click-away / click-back bug the user actually saw:
+    // after clicking a different video and clicking back, the original
+    // video's saved progress was wiped to 0 in the database and the next
+    // open seeked to 0.
     //
-    // Discriminating diagnostic: VideoPlayer's onLoadedMetadata calls
-    // applySeek BEFORE emitting to the parent, and that pre-emit applySeek
-    // converges on the right final value either way — so an end-state
-    // assertion would pass without the fix. Instead we install a setter spy
-    // on `video.currentTime` AFTER the smart-open seek but BEFORE the click,
-    // and check the spy log immediately after the click + reactive flush
-    // (still BEFORE we dispatch loadedmetadata). With the fix, the parent
-    // watcher fires on the 100→0 reset and child applySeek writes 0. Without
-    // the fix, no write happens at this stage.
+    // Root cause: in the brief window between playVideo updating
+    // currentVideoId and handleVideoLoaded firing for the new src, any
+    // timeupdate event dispatched on the <video> element runs the parent's
+    // updateProgress, which writes (currentTime / duration) * 100 into
+    // videoProgress[currentVideoId] and POSTs the whole bag via
+    // saveProgress — using the WRONG src's timing, attributed to the
+    // newly-selected video. Click-back attributes the wrong src's 0 to the
+    // original video, the backend persists 0, and the next loadedmetadata
+    // → handleVideoLoaded reads 0 and seeks to 0.
+    //
+    // The fix gates updateProgress on a `transitioning` flag set in
+    // playVideo and cleared in handleVideoLoaded once duration is valid.
+    // The test exercises the race by manually dispatching timeupdate
+    // between the click and the loadedmetadata for the new video, then
+    // asserts the backend still has the original video's saved progress.
 
     const admin = await loginAdmin(request);
     await attachAuthCookie(page, request);
     const userId = admin.id;
 
-    // Find a course with at least 2 videos in the first lesson — required to
-    // exercise the click-away/click-back path.
     const coursesRes = await request.get('/api/courses?limit=20');
     const coursesBody = await coursesRes.json();
     let sample = null;
@@ -115,16 +115,14 @@ test.describe('player resume + smart open', () => {
     expect(sample, 'fixture course with 2+ videos in first lesson should exist').toBeTruthy();
 
     const v0Id = `${lesson.id}-0`;
-    const v1Id = `${lesson.id}-1`;
 
-    // Both videos at 50% — seek targets coincide at (50/100)*200 = 100, which
-    // is the value-equal-write surface the fix is for.
+    // Seed v0 = 50% so smart-open will pick v0 and seek to (50/100)*200 = 100.
     await request.post(`/api/user-progress/${userId}`, {
       data: {
         courseId: sample.id,
         data: {
           completed: {},
-          progress: { [v0Id]: 50, [v1Id]: 50 },
+          progress: { [v0Id]: 50 },
           favorite: false,
           lastViewed: { lessonId: lesson.id, videoIndex: 0 },
         },
@@ -134,56 +132,55 @@ test.describe('player resume + smart open', () => {
     await page.goto(`/courses/${sample.id}`);
     await page.waitForSelector('video', { timeout: 5_000 });
 
-    // Initial smart-open seek: stub duration to 200 and dispatch
-    // loadedmetadata so handleVideoLoaded computes the seek target.
+    // Stub duration so handleVideoLoaded has a sane number to multiply
+    // against the saved percentage. The element is reused across src
+    // changes, so the stub holds for the whole test.
     await page.evaluate(() => {
       const v = document.querySelector('video');
       Object.defineProperty(v, 'duration', { configurable: true, get: () => 200 });
       Object.defineProperty(v, 'readyState', { configurable: true, get: () => 1 });
       v.dispatchEvent(new Event('loadedmetadata'));
     });
+
+    // Sanity: smart-open + handleVideoLoaded landed on v0 at ~100.
     const initialCt = await page.evaluate(() => document.querySelector('video').currentTime);
     expect(initialCt, 'smart-open should seek v0 to ~100').toBeGreaterThanOrEqual(50);
 
-    // Install the spy. The getter mirrors the last set so applySeek's diff
-    // check still works; the setter records every write. window.__seekLog
-    // captures the discriminating signal.
-    await page.evaluate(() => {
-      const v = document.querySelector('video');
-      window.__seekLog = [];
-      let _ct = v.currentTime || 0;
-      Object.defineProperty(v, 'currentTime', {
-        configurable: true,
-        get: () => _ct,
-        set: (val) => { window.__seekLog.push(val); _ct = val; },
-      });
-    });
-
-    // Click v1. With the fix, playVideo writes currentTimeForPlayer = 0 →
-    // parent's currentTime watcher → child's applySeek → spy records 0.
-    // Without the fix, nothing writes to currentTime in this window.
+    // Click v1, then immediately fire a timeupdate. This is the racy
+    // event the bug depends on: currentVideoId is now v1's, but no
+    // loadedmetadata has fired for v1 yet. Without the gate, updateProgress
+    // would write 0 to videoProgress[v1] and POST it; with the gate, it's
+    // a no-op.
     await page.locator(`[data-testid="lesson-video-${lesson.id}-1"]`).click();
-    // > 100ms so playVideo's autoplay setTimeout(100) also settles harmlessly.
-    await page.waitForTimeout(150);
-
-    const seeksAfterClick = await page.evaluate(() => window.__seekLog.slice());
-    expect(
-      seeksAfterClick.includes(0),
-      `expected playVideo's parent-side currentTimeForPlayer reset to drive a write of 0 (got ${JSON.stringify(seeksAfterClick)})`
-    ).toBe(true);
-
-    // Now finish the seek pipeline: a real browser would have called .load()
-    // (resetting currentTime to 0) and fired loadedmetadata. Mirror that and
-    // verify handleVideoLoaded reseeked to the saved-progress target.
+    await page.waitForTimeout(50);
     await page.evaluate(() => {
       const v = document.querySelector('video');
       v.currentTime = 0;
-      v.dispatchEvent(new Event('loadedmetadata'));
+      v.dispatchEvent(new Event('timeupdate'));
     });
-    await page.waitForTimeout(50);
+    // Let saveProgress (debounce-free, fire-and-forget) settle.
+    await page.waitForTimeout(150);
 
-    const v1Ct = await page.evaluate(() => document.querySelector('video').currentTime);
-    expect(v1Ct, 'v1 should resume to ~100s (50% of 200)').toBeGreaterThanOrEqual(50);
+    // Now the dangerous click — click back to v0. The race attributes
+    // the post-load 0 timing to v0 and would persist v0 = 0.
+    await page.locator(`[data-testid="lesson-video-${lesson.id}-0"]`).click();
+    await page.waitForTimeout(50);
+    await page.evaluate(() => {
+      const v = document.querySelector('video');
+      v.currentTime = 0;
+      v.dispatchEvent(new Event('timeupdate'));
+    });
+    await page.waitForTimeout(150);
+
+    // Read the persisted progress. With the fix, v0 is still 50.
+    // Without the fix, v0 is 0.
+    const progressRes = await request.get(`/api/user-progress/${userId}`);
+    const progressBody = await progressRes.json();
+    const persisted = progressBody?.progress?.[sample.id]?.progress?.[v0Id];
+    expect(
+      Number(persisted),
+      `expected videoProgress[${v0Id}] to remain ~50 across click-away/click-back; got ${persisted}`
+    ).toBeGreaterThanOrEqual(40);
   });
 
   test('parent owns the seek (regression for the loadedmetadata race bug)', async ({ page, request }) => {

--- a/frontend/tests/e2e/player-resume.spec.js
+++ b/frontend/tests/e2e/player-resume.spec.js
@@ -181,6 +181,32 @@ test.describe('player resume + smart open', () => {
       Number(persisted),
       `expected videoProgress[${v0Id}] to remain ~50 across click-away/click-back; got ${persisted}`
     ).toBeGreaterThanOrEqual(40);
+
+    // Now dispatch a real loadedmetadata for v0 so handleVideoLoaded clears
+    // the transition gate, then drive a fresh timeupdate at a NEW position
+    // and verify the backend reflects it. This catches a pathological
+    // version of the fix where transitioning is set true and never cleared
+    // — saves would be permanently disabled and the earlier assertion
+    // alone would still pass.
+    await page.evaluate(() => {
+      const v = document.querySelector('video');
+      v.dispatchEvent(new Event('loadedmetadata'));
+    });
+    await page.waitForTimeout(50);
+    await page.evaluate(() => {
+      const v = document.querySelector('video');
+      v.currentTime = 120; // 60% of 200
+      v.dispatchEvent(new Event('timeupdate'));
+    });
+    await page.waitForTimeout(200);
+
+    const resumedRes = await request.get(`/api/user-progress/${userId}`);
+    const resumedBody = await resumedRes.json();
+    const resumed = Number(resumedBody?.progress?.[sample.id]?.progress?.[v0Id]);
+    expect(
+      resumed,
+      `after handleVideoLoaded for v0, a fresh timeupdate at 60% must persist (got ${resumed})`
+    ).toBeGreaterThanOrEqual(55);
   });
 
   test('parent owns the seek (regression for the loadedmetadata race bug)', async ({ page, request }) => {

--- a/frontend/tests/e2e/player-resume.spec.js
+++ b/frontend/tests/e2e/player-resume.spec.js
@@ -73,15 +73,25 @@ test.describe('player resume + smart open', () => {
   });
 
   test('clicking a partially-watched video resumes from saved position', async ({ page, request }) => {
-    // Regression for the click-to-resume bug: when the user clicked a video
-    // in the lesson list whose saved progress mapped to the SAME numeric
-    // currentTimeForPlayer value as the previously-selected video,
-    // VideoPlayer's currentTime watcher (Vue value-change semantics) did not
-    // fire and the freshly-loaded element stayed at 0.
+    // Regression for the click-to-resume bug. VideoPlayer's currentTime
+    // watcher only fires on value-change (Vue ref semantics), so when
+    // handleVideoLoaded reassigns currentTimeForPlayer to the SAME numeric
+    // value as before — easy to hit with two videos at the same saved-progress
+    // percentage and same duration — no seek lands on the freshly-loaded
+    // element. The fix resets currentTimeForPlayer to 0 inside playVideo on
+    // video change so the parent watcher's next write is always a value
+    // transition.
     //
-    // The fix resets currentTimeForPlayer to 0 inside playVideo whenever the
-    // selected video changes, so handleVideoLoaded's later assignment is
-    // always a value transition and the watcher always seeks.
+    // Discriminating diagnostic: VideoPlayer's onLoadedMetadata calls
+    // applySeek BEFORE emitting to the parent, and that pre-emit applySeek
+    // converges on the right final value either way — so an end-state
+    // assertion would pass without the fix. Instead we install a setter spy
+    // on `video.currentTime` AFTER the smart-open seek but BEFORE the click,
+    // and check the spy log immediately after the click + reactive flush
+    // (still BEFORE we dispatch loadedmetadata). With the fix, the parent
+    // watcher fires on the 100→0 reset and child applySeek writes 0. Without
+    // the fix, no write happens at this stage.
+
     const admin = await loginAdmin(request);
     await attachAuthCookie(page, request);
     const userId = admin.id;
@@ -107,8 +117,8 @@ test.describe('player resume + smart open', () => {
     const v0Id = `${lesson.id}-0`;
     const v1Id = `${lesson.id}-1`;
 
-    // Seed BOTH videos with the same saved-progress percentage so the buggy
-    // value-equal write path is what we're actually exercising.
+    // Both videos at 50% — seek targets coincide at (50/100)*200 = 100, which
+    // is the value-equal-write surface the fix is for.
     await request.post(`/api/user-progress/${userId}`, {
       data: {
         courseId: sample.id,
@@ -124,50 +134,56 @@ test.describe('player resume + smart open', () => {
     await page.goto(`/courses/${sample.id}`);
     await page.waitForSelector('video', { timeout: 5_000 });
 
-    // Stub duration permanently on this <video> instance. The element is
-    // reused across src changes (v-if="src" stays truthy), so one stub holds
-    // for the whole test.
+    // Initial smart-open seek: stub duration to 200 and dispatch
+    // loadedmetadata so handleVideoLoaded computes the seek target.
     await page.evaluate(() => {
       const v = document.querySelector('video');
       Object.defineProperty(v, 'duration', { configurable: true, get: () => 200 });
       Object.defineProperty(v, 'readyState', { configurable: true, get: () => 1 });
-      try { v.currentTime = 0; } catch {}
       v.dispatchEvent(new Event('loadedmetadata'));
     });
-
-    // Smart-open lands on v0 (first not completed) → seek to (50/100)*200 = 100.
     const initialCt = await page.evaluate(() => document.querySelector('video').currentTime);
-    expect(initialCt).toBeGreaterThanOrEqual(50);
+    expect(initialCt, 'smart-open should seek v0 to ~100').toBeGreaterThanOrEqual(50);
 
-    // Click v1. Seek target should also be 100 (same percent, same duration).
+    // Install the spy. The getter mirrors the last set so applySeek's diff
+    // check still works; the setter records every write. window.__seekLog
+    // captures the discriminating signal.
+    await page.evaluate(() => {
+      const v = document.querySelector('video');
+      window.__seekLog = [];
+      let _ct = v.currentTime || 0;
+      Object.defineProperty(v, 'currentTime', {
+        configurable: true,
+        get: () => _ct,
+        set: (val) => { window.__seekLog.push(val); _ct = val; },
+      });
+    });
+
+    // Click v1. With the fix, playVideo writes currentTimeForPlayer = 0 →
+    // parent's currentTime watcher → child's applySeek → spy records 0.
+    // Without the fix, nothing writes to currentTime in this window.
     await page.locator(`[data-testid="lesson-video-${lesson.id}-1"]`).click();
-    // Reactive flush + simulated browser-side reload: load() in a real
-    // Chromium resets currentTime to 0; mirror that here so we measure the
-    // parent's seek pipeline rather than residual state from the previous src.
-    await page.waitForTimeout(50);
-    await page.evaluate(() => {
-      const v = document.querySelector('video');
-      try { v.currentTime = 0; } catch {}
-      v.dispatchEvent(new Event('loadedmetadata'));
-    });
-    await page.waitForTimeout(50);
-    const v1Ct = await page.evaluate(() => document.querySelector('video').currentTime);
-    // With the fix, the watcher fires (100 → 0 inside playVideo, then 0 → 100
-    // from handleVideoLoaded) and the player seeks to ~100. Without the fix,
-    // the 100 → 100 write is a no-op and currentTime stays at 0.
-    expect(v1Ct, 'v1 should resume to 50% of 200 = 100').toBeGreaterThanOrEqual(50);
+    // > 100ms so playVideo's autoplay setTimeout(100) also settles harmlessly.
+    await page.waitForTimeout(150);
 
-    // Click v0 again. Same target. Same regression surface.
-    await page.locator(`[data-testid="lesson-video-${lesson.id}-0"]`).click();
-    await page.waitForTimeout(50);
+    const seeksAfterClick = await page.evaluate(() => window.__seekLog.slice());
+    expect(
+      seeksAfterClick.includes(0),
+      `expected playVideo's parent-side currentTimeForPlayer reset to drive a write of 0 (got ${JSON.stringify(seeksAfterClick)})`
+    ).toBe(true);
+
+    // Now finish the seek pipeline: a real browser would have called .load()
+    // (resetting currentTime to 0) and fired loadedmetadata. Mirror that and
+    // verify handleVideoLoaded reseeked to the saved-progress target.
     await page.evaluate(() => {
       const v = document.querySelector('video');
-      try { v.currentTime = 0; } catch {}
+      v.currentTime = 0;
       v.dispatchEvent(new Event('loadedmetadata'));
     });
     await page.waitForTimeout(50);
-    const v0Ct = await page.evaluate(() => document.querySelector('video').currentTime);
-    expect(v0Ct, 'v0 should resume to 50% of 200 = 100 on click-back').toBeGreaterThanOrEqual(50);
+
+    const v1Ct = await page.evaluate(() => document.querySelector('video').currentTime);
+    expect(v1Ct, 'v1 should resume to ~100s (50% of 200)').toBeGreaterThanOrEqual(50);
   });
 
   test('parent owns the seek (regression for the loadedmetadata race bug)', async ({ page, request }) => {

--- a/frontend/tests/e2e/player-resume.spec.js
+++ b/frontend/tests/e2e/player-resume.spec.js
@@ -172,15 +172,19 @@ test.describe('player resume + smart open', () => {
     });
     await page.waitForTimeout(150);
 
-    // Read the persisted progress. With the fix, v0 is still 50.
-    // Without the fix, v0 is 0.
+    // Read the persisted progress. With the fix, v0 is still exactly 50
+    // (the seeded value, no save calls happened — gates prevented all
+    // updateProgress writes during the transition). Without the fix, the
+    // stale-timeupdate writes 0 and the backend persists it. We assert the
+    // exact seeded value so a wrong-src overwrite to any other value
+    // (including a bogus high number) also fails.
     const progressRes = await request.get(`/api/user-progress/${userId}`);
     const progressBody = await progressRes.json();
     const persisted = progressBody?.progress?.[sample.id]?.progress?.[v0Id];
     expect(
       Number(persisted),
-      `expected videoProgress[${v0Id}] to remain ~50 across click-away/click-back; got ${persisted}`
-    ).toBeGreaterThanOrEqual(40);
+      `expected videoProgress[${v0Id}] to remain exactly 50 across click-away/click-back; got ${persisted}`
+    ).toBe(50);
 
     // Now dispatch a real loadedmetadata for v0 so handleVideoLoaded clears
     // the transition gate, then drive a fresh timeupdate at a NEW position

--- a/frontend/tests/e2e/player-resume.spec.js
+++ b/frontend/tests/e2e/player-resume.spec.js
@@ -72,6 +72,104 @@ test.describe('player resume + smart open', () => {
     await expect(page.locator('[data-testid=player-speed]')).toBeVisible({ timeout: 5_000 });
   });
 
+  test('clicking a partially-watched video resumes from saved position', async ({ page, request }) => {
+    // Regression for the click-to-resume bug: when the user clicked a video
+    // in the lesson list whose saved progress mapped to the SAME numeric
+    // currentTimeForPlayer value as the previously-selected video,
+    // VideoPlayer's currentTime watcher (Vue value-change semantics) did not
+    // fire and the freshly-loaded element stayed at 0.
+    //
+    // The fix resets currentTimeForPlayer to 0 inside playVideo whenever the
+    // selected video changes, so handleVideoLoaded's later assignment is
+    // always a value transition and the watcher always seeks.
+    const admin = await loginAdmin(request);
+    await attachAuthCookie(page, request);
+    const userId = admin.id;
+
+    // Find a course with at least 2 videos in the first lesson — required to
+    // exercise the click-away/click-back path.
+    const coursesRes = await request.get('/api/courses?limit=20');
+    const coursesBody = await coursesRes.json();
+    let sample = null;
+    let lesson = null;
+    for (const item of coursesBody.items || []) {
+      const cRes = await request.get(`/api/courses/${item.id}`);
+      const cData = await cRes.json();
+      const l0 = cData.lessons?.[0];
+      if (l0 && l0.videos && l0.videos.length >= 2) {
+        sample = cData;
+        lesson = l0;
+        break;
+      }
+    }
+    expect(sample, 'fixture course with 2+ videos in first lesson should exist').toBeTruthy();
+
+    const v0Id = `${lesson.id}-0`;
+    const v1Id = `${lesson.id}-1`;
+
+    // Seed BOTH videos with the same saved-progress percentage so the buggy
+    // value-equal write path is what we're actually exercising.
+    await request.post(`/api/user-progress/${userId}`, {
+      data: {
+        courseId: sample.id,
+        data: {
+          completed: {},
+          progress: { [v0Id]: 50, [v1Id]: 50 },
+          favorite: false,
+          lastViewed: { lessonId: lesson.id, videoIndex: 0 },
+        },
+      },
+    });
+
+    await page.goto(`/courses/${sample.id}`);
+    await page.waitForSelector('video', { timeout: 5_000 });
+
+    // Stub duration permanently on this <video> instance. The element is
+    // reused across src changes (v-if="src" stays truthy), so one stub holds
+    // for the whole test.
+    await page.evaluate(() => {
+      const v = document.querySelector('video');
+      Object.defineProperty(v, 'duration', { configurable: true, get: () => 200 });
+      Object.defineProperty(v, 'readyState', { configurable: true, get: () => 1 });
+      try { v.currentTime = 0; } catch {}
+      v.dispatchEvent(new Event('loadedmetadata'));
+    });
+
+    // Smart-open lands on v0 (first not completed) → seek to (50/100)*200 = 100.
+    const initialCt = await page.evaluate(() => document.querySelector('video').currentTime);
+    expect(initialCt).toBeGreaterThanOrEqual(50);
+
+    // Click v1. Seek target should also be 100 (same percent, same duration).
+    await page.locator(`[data-testid="lesson-video-${lesson.id}-1"]`).click();
+    // Reactive flush + simulated browser-side reload: load() in a real
+    // Chromium resets currentTime to 0; mirror that here so we measure the
+    // parent's seek pipeline rather than residual state from the previous src.
+    await page.waitForTimeout(50);
+    await page.evaluate(() => {
+      const v = document.querySelector('video');
+      try { v.currentTime = 0; } catch {}
+      v.dispatchEvent(new Event('loadedmetadata'));
+    });
+    await page.waitForTimeout(50);
+    const v1Ct = await page.evaluate(() => document.querySelector('video').currentTime);
+    // With the fix, the watcher fires (100 → 0 inside playVideo, then 0 → 100
+    // from handleVideoLoaded) and the player seeks to ~100. Without the fix,
+    // the 100 → 100 write is a no-op and currentTime stays at 0.
+    expect(v1Ct, 'v1 should resume to 50% of 200 = 100').toBeGreaterThanOrEqual(50);
+
+    // Click v0 again. Same target. Same regression surface.
+    await page.locator(`[data-testid="lesson-video-${lesson.id}-0"]`).click();
+    await page.waitForTimeout(50);
+    await page.evaluate(() => {
+      const v = document.querySelector('video');
+      try { v.currentTime = 0; } catch {}
+      v.dispatchEvent(new Event('loadedmetadata'));
+    });
+    await page.waitForTimeout(50);
+    const v0Ct = await page.evaluate(() => document.querySelector('video').currentTime);
+    expect(v0Ct, 'v0 should resume to 50% of 200 = 100 on click-back').toBeGreaterThanOrEqual(50);
+  });
+
   test('parent owns the seek (regression for the loadedmetadata race bug)', async ({ page, request }) => {
     // This test verifies the architectural fix without relying on a valid
     // video file. We stub `video.duration` and dispatch `loadedmetadata`


### PR DESCRIPTION
## Summary

- **Sort dropdown alignment**: dropdown next to the search bar now matches the search input height; `mb-6` moved off `SearchBar` so `items-center` actually centers both controls.
- **Clickable header logo + name**: wrapped in `<NuxtLink to=\"/courses\">` on both `pages/courses/index.vue` and `components/course/CourseHeader.vue`. CourseHeader uses `hidden sm:flex` on the link itself so the focusable target matches the visible footprint (no phantom mobile tab stop).
- **Click-to-resume + progress-reset bug** (the real one): clicking another video and back was wiping the original video's saved progress and restarting it from 0. Root cause: a stale `timeupdate` during the brief window between `playVideo` updating `currentVideoId` and `handleVideoLoaded` firing for the new src ran `updateProgress` against the wrong-src timing but attributed the result to the newly-selected video, then `saveProgress` persisted it. Layered defenses: `transitioning` ref gates `updateProgress` and `markAsCompleted`; `expectedSrc` token rejects stale `loadedmetadata` from a superseded `load()`; `forceFromZeroFor` videoId token replaces a global boolean and is cleared in `playVideo` on video change so a same-src rewind cannot poison a future click-back; same-URL different-id swap is handled synchronously (with an explicit `setCurrentTime` call after the synchronous `handleVideoLoaded` so Vue watcher coalescing can't strand the element). Lesson row refactor: `@click` lives on the wrapper that owns `data-testid`, the whole row is clickable, and the action buttons (toggle-completion, reset-progress) get `@click.stop` so they don't bubble into `playVideo`.
- **Start-from-beginning button**: styled as a proper button anchored to the right of `VideoPlayer`'s controls bar (alongside Speed) and now rewinds the **current** video, not jump to the course's first lesson. Emits a `start-from-beginning` event so the parent owns the rewind handler.

## Test plan

- [x] `npx vitest run` from `frontend/` — 19/19 files, 172/172 tests pass.
- [x] Codex review iterated to CLEAN (5 rounds; every HIGH/MEDIUM/LOW finding fixed before merge per project policy).
- [x] Playwright end-to-end verification on a fresh tmpfs build: smart-open seeks v0 to its saved %, click v1 with stale timeupdate during transition (gated), click back to v0 with another stale timeupdate (gated), backend `lesson-1-0` unchanged at exactly 50; after `loadedmetadata` for v0, gate clears, fresh timeupdate at 60% persists; Start-from-beginning rewinds v0 to 0 and stays on v0; subsequent click on v1 resumes to its own saved 40% (force-from-zero token correctly scoped).
- [x] New e2e regression: `frontend/tests/e2e/player-resume.spec.js` — seeds two videos at the same percentage, exercises the actual race (stale timeupdate during transition), asserts exact persisted v0 = 50, then dispatches a real `loadedmetadata` and asserts saves resume.