### PR TITLE
fix(courses): wire user-menu items on course detail page

### DIFF
--- a/frontend/components/course/CourseHeader.vue
+++ b/frontend/components/course/CourseHeader.vue
@@ -72,10 +72,13 @@
             <path fill-rule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clip-rule="evenodd" />
           </svg>
         </button>
-        <UserProfile 
-          :user="user" 
-          @logout="$emit('logout')" 
-          @delete="navigateBack"
+        <UserProfile
+          :user="user"
+          @logout="$emit('logout')"
+          @delete="$emit('delete')"
+          @manage="$emit('manage')"
+          @admin="$emit('admin')"
+          @rescan="$emit('rescan')"
         />
         <ThemeToggle />
       </div>
@@ -122,9 +125,10 @@ const props = defineProps({
 });
 
 // Define emitted events
-const emit = defineEmits(['toggle-favorite', 'mark-completed', 'reset-progress', 'logout']);
+const emit = defineEmits(['toggle-favorite', 'mark-completed', 'reset-progress', 'logout', 'delete', 'manage', 'admin', 'rescan']);
 
-// Navigation method
+// Navigation method (back arrow only — Delete Account routes to the parent
+// page's confirmation modal so the destructive action stays gated).
 function navigateBack() {
   router.push('/courses');
 }

--- a/frontend/pages/courses/[id].vue
+++ b/frontend/pages/courses/[id].vue
@@ -11,7 +11,71 @@
       @mark-completed="markCourseCompleted"
       @reset-progress="resetCourseProgress"
       @logout="logout"
+      @delete="showDeleteConfirm = true"
+      @manage="showUserManagement = true"
+      @admin="showAdminPanel = true"
+      @rescan="showRescanConfirm = true"
     />
+
+    <!-- Delete-account confirmation -->
+    <ConfirmationModal
+      v-if="showDeleteConfirm"
+      title="Delete Account"
+      message="Are you sure you want to delete your account? This action cannot be undone and all your progress will be lost."
+      confirm-button-text="Delete Account"
+      cancel-button-text="Cancel"
+      confirm-button-color="red"
+      :show="showDeleteConfirm"
+      :is-loading="isDeleting"
+      loading-text="Deleting..."
+      @confirm="deleteAccount"
+      @cancel="showDeleteConfirm = false"
+    />
+
+    <!-- My Profile modal (personal: name, avatar, password, PIN) -->
+    <UserManagement
+      v-if="showUserManagement"
+      :show="showUserManagement"
+      :user="userObject"
+      @close="showUserManagement = false"
+      @updated="showUserManagement = false"
+    />
+
+    <!-- Admin Panel modal (admin-only entry; server enforces authz) -->
+    <AdminPanel
+      v-if="showAdminPanel"
+      :show="showAdminPanel"
+      @close="showAdminPanel = false"
+    />
+
+    <!-- Rescan confirmation -->
+    <ConfirmationModal
+      v-if="showRescanConfirm"
+      title="Database Rescan"
+      message="Are you sure you want to rescan the courses database?"
+      confirm-button-text="Rescan Database"
+      cancel-button-text="Cancel"
+      :show="showRescanConfirm"
+      @confirm="confirmRescan"
+      @cancel="showRescanConfirm = false"
+    >
+      <div class="mb-6">
+        <div class="flex items-center mb-2">
+          <input
+            id="preserve-metadata"
+            v-model="preserveMetadata"
+            type="checkbox"
+            class="rounded text-primary-500 focus:ring-primary-500 dark:bg-gray-700 dark:border-gray-600"
+          />
+          <label for="preserve-metadata" class="ml-2 text-sm text-gray-700 dark:text-gray-300">
+            Preserve course metadata (thumbnails, descriptions, etc.)
+          </label>
+        </div>
+        <p class="text-sm text-gray-500 dark:text-gray-400 italic">
+          If unchecked, all custom metadata will be reset to defaults.
+        </p>
+      </div>
+    </ConfirmationModal>
     
     <main class="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
       <!-- Video Player -->
@@ -128,6 +192,9 @@ import VideoPlayer from '../../components/video/VideoPlayer.vue';
 import VideoInfo from '../../components/video/VideoInfo.vue';
 import { pickNextNotCompleted } from '~/utils/smartOpen.js';
 import VideoControlButtons from '../../components/video/VideoControlButtons.vue';
+import UserManagement from '../../components/UserManagement.vue';
+import AdminPanel from '../../components/AdminPanel.vue';
+import ConfirmationModal from '../../components/ui/ConfirmationModal.vue';
 
 // Apply auth middleware
 definePageMeta({
@@ -138,16 +205,67 @@ const route = useRoute();
 const router = useRouter();
 
 // Get user from session composable
-const { userName, userAvatar, logout, userId, isAdmin } = useSession();
+const { userName, userAvatar, logout, deleteAccount: userDelete, userId, isAdmin, isActive } = useSession();
 
-// Create a computed user object with the correct structure
+// Create a computed user object with the correct structure. Must include
+// id so the My Profile (UserManagement) modal knows which user to load and
+// patch — without it the modal opens against an undefined user and silently
+// no-ops.
 const userObject = computed(() => {
   return {
+    id: userId.value,
     name: userName.value,
     avatar: userAvatar.value,
-    isAdmin: isAdmin.value ? 1 : 0
+    isAdmin: isAdmin.value ? 1 : 0,
+    is_active: isActive.value ? 1 : 0,
   };
 });
+
+// User-menu modal state. The user-menu in the header (UserProfile) emits
+// `manage` / `admin` / `rescan` / `delete`; before this fix CourseHeader
+// dropped manage/admin/rescan silently and routed delete to a back-button
+// navigation (no confirmation, no actual deletion).
+const showUserManagement = ref(false);
+const showAdminPanel = ref(false);
+const showRescanConfirm = ref(false);
+const showDeleteConfirm = ref(false);
+const isDeleting = ref(false);
+const preserveMetadata = ref(true);
+
+async function confirmRescan() {
+  showRescanConfirm.value = false;
+  try {
+    const response = await $fetch('/api/courses/rescan', {
+      method: 'POST',
+      body: { preserveMetadata: preserveMetadata.value },
+    });
+    if (!response?.success) {
+      console.error('Failed to start rescan:', response?.error || 'Unknown error');
+      alert(`Failed to start database rescan: ${response?.error || 'Unknown error'}`);
+    }
+  } catch (err) {
+    console.error('Error initiating rescan:', err);
+    alert(`Error initiating database rescan: ${err.message || 'Unknown error'}`);
+  }
+}
+
+async function deleteAccount() {
+  showDeleteConfirm.value = false;
+  isDeleting.value = true;
+  try {
+    const result = await userDelete();
+    if (!result?.success) {
+      console.error('Failed to delete account:', result?.message);
+      alert(`Failed to delete account: ${result?.message || 'Unknown error'}`);
+    }
+    // On success the useSession composable already logs out and redirects.
+  } catch (err) {
+    console.error('Error deleting account:', err);
+    alert('An error occurred while trying to delete your account.');
+  } finally {
+    isDeleting.value = false;
+  }
+}
 
 // State
 const course = ref({


### PR DESCRIPTION
## Summary

User-reported: clicking **My Profile** in the user-menu dropdown works on `/courses` but does nothing on `/courses/:id` (silent dead-link, no console error).

Root cause: `UserProfile` emits `manage` / `admin` / `rescan` / `delete`. On `/courses` the parent listens for all four and opens the appropriate modal. On `/courses/:id` the parent (`CourseHeader`) declared only `['toggle-favorite', 'mark-completed', 'reset-progress', 'logout']` in `defineEmits` and forwarded only `@logout` + `@delete` on its inner `UserProfile` — and `@delete` was wired to `navigateBack` instead of an actual delete confirmation. Net effect: clicking My Profile / Admin Panel / Rescan Database / Delete Account from the user menu while watching a video did nothing visible (manage/admin/rescan) or silently left the page (delete).

## Fix

- `CourseHeader.vue`: declare `manage` / `admin` / `rescan` / `delete` in `defineEmits`; inner `UserProfile` forwards them all via `$emit`. `navigateBack` stays as the back-arrow handler only.
- `pages/courses/[id].vue`: extend `userObject` to include `id` and `is_active` from `useSession` (`UserManagement` bails on missing `id` — even if `manage` had been wired, the modal would have silently no-op'd). Import `UserManagement`, `AdminPanel`, `ConfirmationModal`. Render all four modals conditionally. Add `deleteAccount` (proxies `useSession`'s `userDelete`, surfaces failure via `alert` + `console.error`) and `confirmRescan` (POSTs `/api/courses/rescan` and checks `response.success`, matching the index page's behaviour).

## Test plan

- [x] Visually verified end-to-end on a fresh prod build (Dockerfile.prod) against `manual-test/data` with real content: opening the user menu on `/courses/:id` and clicking each of My Profile / Admin Panel / Rescan Database / Delete Account opens its proper modal.
- [x] Codex review iterated to CLEAN (2 passes; pass 1 flagged the delete-route inconsistency and the unchecked rescan response — both fixed).