### PR TITLE
ci(docker): publish :beta on every push to main and a manual :latest promote

### DIFF
--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -1,0 +1,38 @@
+# Manual promotion of the current vladoportos/skillgoblin:beta image to
+# :latest. Run from GitHub: Actions tab → "Promote :beta to :latest" →
+# Run workflow.
+#
+# This does NOT rebuild the image. `docker buildx imagetools create`
+# copies the manifest under a new tag, so :latest after promotion is
+# byte-identical to the :beta you tested. Operation is a registry-side
+# metadata write — completes in seconds.
+#
+# Intentionally workflow_dispatch only — no automatic trigger ever
+# touches :latest.
+
+name: Promote :beta to :latest
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Re-tag :beta as :latest (no rebuild)
+        run: |
+          docker buildx imagetools create \
+            --tag vladoportos/skillgoblin:latest \
+            vladoportos/skillgoblin:beta

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,54 @@
+# Builds the production Docker image on every push to main (which is what
+# happens when a PR is merged) and pushes it to Docker Hub as
+# vladoportos/skillgoblin:beta. Always overwrites :beta — no SHA tags, no
+# other tags, and :latest is intentionally NOT touched. The companion
+# workflow (docker-promote.yml) is the only path that moves :latest, and
+# it re-tags this exact :beta manifest rather than rebuilding.
+#
+# Trigger workflow_dispatch lets the maintainer manually re-publish the
+# current main without an empty commit (e.g. if a transient registry
+# outage failed an earlier run).
+
+name: Publish beta to Docker Hub
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# A second push to main cancels an in-flight build so the registry never
+# settles on an older commit's image.
+concurrency:
+  group: docker-publish-beta
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push :beta
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.prod
+          platforms: linux/amd64
+          push: true
+          tags: vladoportos/skillgoblin:beta
+          # Reuse layers across runs to keep build time low.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Two workflow files. Together they give you a hands-off rolling `:beta` plus a one-button `:latest` promote.

### `.github/workflows/docker-publish.yml`
- Trigger: `push` to `main` (every PR merge) plus `workflow_dispatch` (so you can manually re-publish without an empty commit if a build fails on a transient registry hiccup).
- Builds `Dockerfile.prod` for **linux/amd64** only.
- Pushes a single tag: `vladoportos/skillgoblin:beta`. Always rolling — no SHA tags, no other tags. `:latest` is intentionally never touched.
- `concurrency: cancel-in-progress: true` so a second merge cancels an in-flight build — registry never settles on an older commit's image.
- GitHub Actions cache (`type=gha`) so unchanged layers don't rebuild.

### `.github/workflows/docker-promote.yml`
- `workflow_dispatch` only — runs when you click "Run workflow" in the Actions tab.
- Uses `docker buildx imagetools create` to **copy the `:beta` manifest under `:latest`**. No rebuild. The bytes shipped as `:latest` are byte-identical to the `:beta` you tested. Operation is registry-side and finishes in seconds.

Both pin `permissions: contents: read` defensively.

## Setup expected (you've already done this)

- Docker Hub PAT scoped to `vladoportos/skillgoblin` (read/write/delete).
- GitHub repo secrets: `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`.

## Test plan

- [ ] Merge this PR → `Publish beta to Docker Hub` workflow runs → `vladoportos/skillgoblin:beta` exists on Docker Hub.
- [ ] Check the Docker Hub page: `:latest` is unchanged (its existing digest stays put).
- [ ] Pull `vladoportos/skillgoblin:beta` and verify it boots against `manual-test/data`.
- [ ] When ready: Actions tab → "Promote :beta to :latest" → Run workflow → confirm `:latest` digest now matches `:beta` digest.