### PR TITLE
fix(thumbnail): drop unused path import from thumbnailUtils

### DIFF
--- a/frontend/server/utils/thumbnailUtils.js
+++ b/frontend/server/utils/thumbnailUtils.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import path from 'path';
 import sharp from 'sharp';
 import { resolveCourseDir } from './courseHelpers';
 


### PR DESCRIPTION
Resolves the CodeQL alert (js/unused-local-variable, alert #140) on `frontend/server/utils/thumbnailUtils.js:2`. `path` was imported but only referenced inside JSDoc text — not in code. One-line removal, no behavior change.