### PR TITLE
ci(docker): pin GitHub Actions to commit SHAs to satisfy scorecard

### DIFF
--- a/.github/workflows/docker-promote.yml
+++ b/.github/workflows/docker-promote.yml
@@ -21,12 +21,14 @@ permissions:
 jobs:
   promote:
     runs-on: ubuntu-latest
+    # Pinned by SHA — see docker-publish.yml for rationale. Dependabot
+    # tracks these via the trailing version comment.
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,21 +28,26 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    # Third-party + first-party Actions are pinned by full commit SHA
+    # to defeat tag-hijack supply-chain attacks (a force-push of v3/v4/v6
+    # would otherwise swap in malicious code on next run). Trailing
+    # comment carries the human-readable version so dependabot's
+    # github-actions ecosystem keeps bumping the SHA on new releases.
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push :beta
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile.prod


### PR DESCRIPTION
Resolves the 6 Scorecard `PinnedDependenciesID` alerts (#141-146).

Each `uses: ...@vN` was a floating tag — if the upstream maintainer's account ever gets compromised and the tag force-pushed, every workflow on the platform that uses the tag executes the malicious code on next run. Pinning by full commit SHA freezes the bytes Actions actually runs, so a tag-hijack cannot reach our workflow.

**Resolved at commit time:**

| Action | SHA |
| --- | --- |
| `actions/checkout@v4` | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `docker/setup-buildx-action@v3` | `8d2750c68a42422c14e847fe6c8ac0403b4cbd6f` |
| `docker/login-action@v3` | `c94ce9fb468520275223c153574b00df6fe4bcc9` |
| `docker/build-push-action@v6` | `10e90e3645eae34f1e60eeb005ba3a3d33f178e8` |

Trailing `# vN` comments are intentional: dependabot's `github-actions` ecosystem (already configured in `.github/dependabot.yml`) parses them and opens bump PRs when upstream cuts new releases, so we get fresh SHAs without dropping the security guarantee.

## Test plan

- [ ] Merge → docker-publish workflow runs once → `vladoportos/skillgoblin:beta` rebuilt and pushed (proves SHAs are valid).
- [ ] Scorecard re-scan closes alerts #141–146.