### PR TITLE
refactor(pin): extract shared PinInput with iOS-style reveal-then-mask

### DIFF
--- a/frontend/components/SetCredentialsModal.vue
+++ b/frontend/components/SetCredentialsModal.vue
@@ -61,22 +61,15 @@
         </div>
 
         <div v-if="mode === 'bootstrap' && allowPin">
-          <label class="block text-sm font-medium text-gray-300 mb-1" for="set-creds-pin">
+          <label class="block text-sm font-medium text-gray-300 mb-2">
             PIN <span class="text-gray-500">(4 digits, optional)</span>
           </label>
-          <input
-            id="set-creds-pin"
+          <PinInput
             v-model="pin"
-            type="password"
-            inputmode="numeric"
-            maxlength="4"
-            pattern="[0-9]{4}"
-            autocomplete="off"
-            data-testid="set-creds-pin"
-            class="w-full px-3 py-2 border border-gray-600 rounded-md bg-gray-700 text-white focus:outline-none focus:ring-blue-500 focus:border-blue-500"
-            placeholder="Optional"
+            id-prefix="set-creds-pin"
+            test-id-prefix="set-creds-pin"
           />
-          <p class="mt-1 text-xs text-gray-400">{{ encourageBothHint }}</p>
+          <p class="mt-2 text-xs text-gray-400 text-center">{{ encourageBothHint }}</p>
         </div>
 
         <p v-if="errorMessage" class="text-sm text-red-400" data-testid="set-creds-error">{{ errorMessage }}</p>
@@ -103,6 +96,7 @@
 
 <script setup>
 import { ref, computed, watch } from 'vue';
+import PinInput from './ui/PinInput.vue';
 
 // Two upgrade scenarios:
 //   mode="bootstrap"   — legacy account with neither password nor PIN.

--- a/frontend/components/UserManagement.vue
+++ b/frontend/components/UserManagement.vue
@@ -120,23 +120,13 @@
             <span v-if="hasPin" class="text-xs text-green-400">✓ set</span>
             <span v-else class="text-xs text-gray-500">not set</span>
           </h3>
-          <div class="flex justify-center space-x-2 pin-input-container mb-3">
-            <input
-              v-for="(_, index) in 4"
-              :key="index"
-              :id="`profile-pin-${index}`"
-              :data-testid="`profile-pin-digit-${index}`"
-              :ref="el => { if (el) newPinInputs[index] = el }"
-              v-model="newPinDigits[index]"
-              type="password"
-              inputmode="numeric"
-              maxlength="1"
-              pattern="[0-9]*"
-              class="w-12 h-12 text-center text-xl border border-gray-600 rounded-md bg-gray-700 text-white"
-              @input="handleNewPinInput($event, index)"
-              @keydown="handleNewPinKeydown($event, index)"
-              @keyup.enter="savePin"
-              aria-label="PIN digit input"
+          <div class="mb-3">
+            <PinInput
+              v-model="newPinDigits"
+              id-prefix="profile-pin"
+              test-id-prefix="profile-pin-digit"
+              digit-class="w-12 h-12 text-center text-xl border border-gray-600 rounded-md bg-gray-700 text-white focus:border-blue-500 focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+              @submit="savePin"
             />
           </div>
           <div class="flex justify-center">
@@ -174,6 +164,7 @@
 import { ref, computed, watch } from 'vue';
 import { Beanhead } from 'beanheads-vue';
 import { useSession } from '~/composables/useSession';
+import PinInput from './ui/PinInput.vue';
 
 const props = defineProps({
   show: {
@@ -202,8 +193,7 @@ const userData = ref({
 // feedback. Profile (name/avatar) save still flows through the form's
 // submit handler below.
 const newPasswordValue = ref('');
-const newPinDigits = ref(['', '', '', '']);
-const newPinInputs = ref([]);
+const newPinDigits = ref('');
 const savingPassword = ref(false);
 const savingPin = ref(false);
 const passwordFeedback = ref('');
@@ -298,31 +288,12 @@ watch(() => props.user, (newUser) => {
 
 function resetCredPanels() {
   newPasswordValue.value = '';
-  newPinDigits.value = ['', '', '', ''];
+  newPinDigits.value = '';
   passwordFeedback.value = '';
   passwordFeedbackError.value = false;
   pinFeedback.value = '';
   pinFeedbackError.value = false;
 }
-
-// PIN grid input handling — digit-only with auto-advance and backspace
-// move-back. Same UX as the signup / login PIN grid.
-const handleNewPinInput = (event, index) => {
-  const value = event.target.value;
-  if (/^\d*$/.test(value)) {
-    newPinDigits.value[index] = value;
-    if (value && index < 3 && newPinInputs.value[index + 1]) {
-      newPinInputs.value[index + 1].focus();
-    }
-  } else {
-    newPinDigits.value[index] = '';
-  }
-};
-const handleNewPinKeydown = (event, index) => {
-  if (event.key === 'Backspace' && !newPinDigits.value[index] && index > 0 && newPinInputs.value[index - 1]) {
-    newPinInputs.value[index - 1].focus();
-  }
-};
 
 // Profile (name + avatar) save — credentials are NOT touched here. The
 // PUT body deliberately omits password/pin so the server's partial-update
@@ -371,7 +342,7 @@ async function savePassword() {
 async function savePin() {
   pinFeedback.value = '';
   pinFeedbackError.value = false;
-  const pin = newPinDigits.value.join('');
+  const pin = newPinDigits.value;
   if (!/^\d{4}$/.test(pin)) {
     pinFeedback.value = 'PIN must be exactly 4 digits.';
     pinFeedbackError.value = true;
@@ -387,7 +358,7 @@ async function savePin() {
     });
     if (result.success) {
       pinFeedback.value = hasPin.value ? 'PIN updated.' : 'PIN saved.';
-      newPinDigits.value = ['', '', '', ''];
+      newPinDigits.value = '';
       authState.value.hasPin = true;
     } else {
       pinFeedback.value = result.message || 'Could not save PIN.';

--- a/frontend/components/ui/PinInput.vue
+++ b/frontend/components/ui/PinInput.vue
@@ -1,0 +1,139 @@
+<template>
+  <div class="flex justify-center space-x-2 pin-input-container">
+    <input
+      v-for="i in 4"
+      :key="i"
+      :ref="el => { inputs[i - 1] = el }"
+      :id="`${idPrefix}-${i - 1}`"
+      :data-testid="testIdPrefix ? `${testIdPrefix}-${i - 1}` : null"
+      :value="displayValue(i - 1)"
+      type="text"
+      inputmode="numeric"
+      pattern="[0-9]*"
+      autocomplete="off"
+      :disabled="disabled"
+      :class="digitClass"
+      :aria-label="`PIN digit ${i}`"
+      @input="onInput($event, i - 1)"
+      @keydown="onKeydown($event, i - 1)"
+      @focus="onFocus($event)"
+      @keyup.enter="$emit('submit')"
+    />
+  </div>
+</template>
+
+<script setup>
+import { ref, watch, onMounted, onBeforeUnmount, nextTick } from 'vue';
+
+const props = defineProps({
+  modelValue:   { type: String,  default: '' },
+  idPrefix:     { type: String,  required: true },
+  testIdPrefix: { type: String,  default: '' },
+  autofocus:    { type: Boolean, default: false },
+  disabled:     { type: Boolean, default: false },
+  digitClass:   {
+    type: String,
+    default:
+      'w-12 h-12 text-center text-2xl bg-gray-700 border border-gray-600 ' +
+      'rounded-md focus:border-blue-500 focus:ring-2 focus:ring-blue-500 ' +
+      'text-white disabled:opacity-50'
+  }
+});
+
+const emit = defineEmits(['update:modelValue', 'submit']);
+
+// iOS-style "reveal last typed digit, then mask" UX. The digit stays visible
+// for REVEAL_MS while the user moves to the next box, then flips to a bullet.
+// Only one digit is ever shown in the clear at a time — typing in any box
+// remasks every other box immediately.
+const REVEAL_MS = 1000;
+const MASK_CHAR = '●';
+
+const inputs = ref([null, null, null, null]);
+const digits = ref(['', '', '', '']);
+const revealedIndex = ref(null);
+let maskTimer = null;
+
+watch(() => props.modelValue, (v) => {
+  // Only resync when the external value differs from what's already rendered.
+  // The guard prevents the watcher firing during our own emitValue() from
+  // overwriting digits and stealing focus mid-typing.
+  if ((v || '') !== digits.value.join('')) {
+    const next = (v || '').slice(0, 4).split('');
+    for (let i = 0; i < 4; i++) digits.value[i] = next[i] || '';
+    // External resets (parent setting modelValue back to '') should also
+    // wipe any pending reveal so a stale digit doesn't briefly flash.
+    cancelReveal();
+  }
+}, { immediate: true });
+
+function emitValue() {
+  emit('update:modelValue', digits.value.join(''));
+}
+
+function displayValue(i) {
+  if (!digits.value[i]) return '';
+  return revealedIndex.value === i ? digits.value[i] : MASK_CHAR;
+}
+
+function startReveal(i) {
+  revealedIndex.value = i;
+  if (maskTimer) clearTimeout(maskTimer);
+  maskTimer = setTimeout(() => {
+    revealedIndex.value = null;
+    maskTimer = null;
+  }, REVEAL_MS);
+}
+
+function cancelReveal() {
+  if (maskTimer) clearTimeout(maskTimer);
+  maskTimer = null;
+  revealedIndex.value = null;
+}
+
+function onInput(event, index) {
+  // The input may contain the mask character (when typing into a previously
+  // masked box) or both the old digit and the new one (when typing into a
+  // currently revealed box). Strip non-digits and keep the last digit typed.
+  const cleaned = (event.target.value || '').replace(/[^0-9]/g, '');
+  if (!cleaned) {
+    digits.value[index] = '';
+    if (revealedIndex.value === index) cancelReveal();
+    emitValue();
+    return;
+  }
+  digits.value[index] = cleaned.slice(-1);
+  startReveal(index);
+  emitValue();
+  if (index < 3) {
+    inputs.value[index + 1]?.focus();
+  }
+}
+
+function onKeydown(event, index) {
+  if (event.key === 'Backspace' && !digits.value[index] && index > 0) {
+    inputs.value[index - 1]?.focus();
+  }
+}
+
+function onFocus(event) {
+  // Select existing content so typing replaces it cleanly. Without this,
+  // typing into a filled box would append to the masked value (e.g. "●5")
+  // and rely on the regex strip — that works, but visually flickers.
+  event.target.select();
+}
+
+function focus() {
+  nextTick(() => inputs.value[0]?.focus());
+}
+
+defineExpose({ focus });
+
+onMounted(() => {
+  if (props.autofocus) focus();
+});
+
+onBeforeUnmount(() => {
+  if (maskTimer) clearTimeout(maskTimer);
+});
+</script>

--- a/frontend/composables/useUserManagement.js
+++ b/frontend/composables/useUserManagement.js
@@ -17,7 +17,7 @@ export function useUserManagement() {
   const showAuthModal = ref(false);
   const authError = ref('');
   const isAuthenticating = ref(false);
-  const pinDigits = ref(['', '', '', '']);
+  const pinDigits = ref('');
   const authData = ref({ password: '', pin: '' });
 
   // Phase 3: surfaces the SetCredentialsModal for legacy no-creds users
@@ -55,7 +55,7 @@ export function useUserManagement() {
   const createError = ref('');
   const useAuth = ref(false);
   const authType = ref('password');
-  const createPinDigits = ref(['', '', '', '']);
+  const createPinDigits = ref('');
   const isAdminCheckbox = ref(false);
 
   const fetchUsers = async () => {
@@ -84,7 +84,7 @@ export function useUserManagement() {
   const selectUser = async (user) => {
     try {
       selectedUser.value = user;
-      pinDigits.value = ['', '', '', ''];
+      pinDigits.value = '';
 
       // Refresh allow_pin before computing the picker matrix — if an admin
       // toggled the setting while the picker page was open, a cached
@@ -164,7 +164,7 @@ export function useUserManagement() {
       const credentials = {};
 
       if (resolvedMode === 'pin') {
-        const enteredPin = pinDigits.value.join('');
+        const enteredPin = pinDigits.value;
         if (enteredPin.length !== 4) {
           authError.value = 'Please enter all 4 digits of your PIN';
           return;

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -201,24 +201,11 @@
             <!-- PIN Input — only when PINs are globally enabled -->
             <div v-if="(authType === 'pin' || authType === 'both') && systemSettings.allow_pin">
               <h3 class="block text-sm font-medium text-gray-300 mb-2">PIN (4 digits)</h3>
-              <div class="flex justify-center space-x-2 pin-input-container">
-                <input
-                  v-for="(digit, index) in 4"
-                  :key="index"
-                  :id="`create-pin-${index}`"
-                  :data-testid="`signup-pin-${index}`"
-                  :ref="el => { if (el && createPinInputs.value) createPinInputs.value[index] = el }"
-                  v-model="createPinDigits[index]"
-                  type="password"
-                  inputmode="numeric"
-                  maxlength="1"
-                  pattern="[0-9]*"
-                  class="w-12 h-12 text-center text-2xl bg-gray-700 border border-gray-600 rounded-md focus:border-blue-500 focus:ring-2 focus:ring-blue-500 text-white"
-                  @input="handleCreatePinInput($event, index)"
-                  @keydown="handleCreatePinKeydown($event, index)"
-                  aria-label="PIN digit input"
-                />
-              </div>
+              <PinInput
+                v-model="createPinDigits"
+                id-prefix="create-pin"
+                test-id-prefix="signup-pin"
+              />
             </div>
           </div>
           
@@ -302,22 +289,11 @@
               <!-- PIN input -->
               <div v-if="loginMode === 'pin'" class="mt-4">
                 <h3 class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">PIN</h3>
-                <div class="flex justify-center space-x-2 pin-input-container">
-                  <input
-                    v-for="(digit, index) in 4"
-                    :key="index"
-                    :id="`pin-${index}`"
-                    :ref="el => { if (el && pinInputs.value) pinInputs.value[index] = el }"
-                    v-model="pinDigits[index]"
-                    type="password"
-                    inputmode="numeric"
-                    maxlength="1"
-                    class="w-12 h-12 text-center text-2xl bg-gray-700 border border-gray-600 rounded focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
-                    @input="handlePinInput($event, index)"
-                    @keydown="handlePinKeydown($event, index)"
-                    aria-label="PIN digit input"
-                  />
-                </div>
+                <PinInput
+                  ref="pinInputRef"
+                  v-model="pinDigits"
+                  id-prefix="pin"
+                />
               </div>
 
               <p v-if="authError" class="text-sm text-red-600 dark:text-red-400">
@@ -367,6 +343,7 @@ import { useSession } from '~/composables/useSession';
 import { useUserManagement } from '~/composables/useUserManagement';
 import AvatarSelector from '../components/AvatarSelector.vue';
 import SetCredentialsModal from '../components/SetCredentialsModal.vue';
+import PinInput from '../components/ui/PinInput.vue';
 import { Beanhead } from 'beanheads-vue';
 
 const branding = useRuntimeConfig().public.branding;
@@ -400,9 +377,9 @@ const {
   finishCredentialUpdate
 } = useUserManagement();
 
-// Local template refs - initialize arrays for PIN inputs
-const pinInputs = ref(Array(4).fill(null));
-const createPinInputs = ref(Array(4).fill(null));
+// Template ref to the login PIN component so we can programmatically focus
+// the first digit when the auth modal opens for a PIN-capable user.
+const pinInputRef = ref(null);
 const passwordInput = ref(null);
 
 // Dismiss handler for SetCredentialsModal. Bootstrap dismissals just close
@@ -418,12 +395,12 @@ function dismissSetCredentials() {
   }
 }
 
-// Make sure refs are initialized when switching auth type
+// Reset the create-user PIN field whenever the auth-type tab switches to PIN
+// (so a stale value from a previous tab visit doesn't survive into the new
+// session). Login PIN gets its own reset in the showAuthModal watcher below.
 watch(() => authType.value, (newAuthType) => {
   if (newAuthType === 'pin') {
-    // Reset PIN arrays when switching to PIN mode
-    createPinInputs.value = Array(4).fill(null);
-    createPinDigits.value = ['', '', '', ''];
+    createPinDigits.value = '';
   }
 });
 const isAdminCheckbox = ref(false);
@@ -437,7 +414,7 @@ watch(() => showAuthModal.value, (isOpen) => {
   // Reset on each open. PIN-default if the user has one; otherwise password.
   loginMode.value = selectedUser.value?.pin ? 'pin' : 'password';
   authData.value = { password: '', pin: '' };
-  pinDigits.value = ['', '', '', ''];
+  pinDigits.value = '';
   authError.value = '';
 });
 // Clear the inactive input when the user toggles modes so a stale value
@@ -446,7 +423,7 @@ watch(loginMode, (mode) => {
   if (mode === 'pin') {
     authData.value.password = '';
   } else {
-    pinDigits.value = ['', '', '', ''];
+    pinDigits.value = '';
   }
   authError.value = '';
 });
@@ -497,7 +474,7 @@ const parseAvatar = (avatarString) => {
 
 // Show the create user modal
 const openCreateUserModal = () => {
-  createPinDigits.value = ['', '', '', ''];
+  createPinDigits.value = '';
   isAdminCheckbox.value = false;
   useAuth.value = true; // auth is mandatory now (the legacy "no-auth" path is gone)
   // Default to password; force it when PINs are disabled globally so the
@@ -588,58 +565,13 @@ onMounted(async () => {
     });
 });
 
-// PIN input handlers
-const handlePinInput = (event, index) => {
-  const value = event.target.value;
-  if (/^\d*$/.test(value)) {
-    pinDigits.value[index] = value;
-    // Immediate focus for next field
-    if (value && index < 3) {
-      const nextInput = event.target.nextElementSibling;
-      if (nextInput && nextInput.tagName === 'INPUT') {
-        nextInput.focus();
-      }
-    }
-  } else {
-    pinDigits.value[index] = '';
-  }
-};
-
-const handlePinKeydown = (event, index) => {
-  if (event.key === 'Backspace' && !pinDigits.value[index] && index > 0 && pinInputs.value?.[index - 1]) {
-    pinInputs.value[index - 1].focus();
-  }
-};
-
-const handleCreatePinInput = (event, index) => {
-  const value = event.target.value;
-  if (/^\d*$/.test(value)) {
-    createPinDigits.value[index] = value;
-    // Immediate focus for next field - use same approach as login PIN input
-    if (value && index < 3) {
-      const nextInput = event.target.nextElementSibling;
-      if (nextInput && nextInput.tagName === 'INPUT') {
-        nextInput.focus();
-      }
-    }
-  } else {
-    createPinDigits.value[index] = '';
-  }
-};
-
-const handleCreatePinKeydown = (event, index) => {
-  if (event.key === 'Backspace' && !createPinDigits.value[index] && index > 0 && createPinInputs.value?.[index - 1]) {
-    createPinInputs.value[index - 1].focus();
-  }
-};
-
-// Auto-focus on input fields when auth modal appears
+// Auto-focus the right input when the auth modal opens. PIN-capable users
+// land on the first digit; password-only users land on the password field.
 watch(showAuthModal, (newValue) => {
   if (newValue) {
     nextTick(() => {
       if (selectedUser.value?.pin) {
-        const firstPinInput = document.querySelector('#pin-0');
-        if (firstPinInput) firstPinInput.focus();
+        pinInputRef.value?.focus();
       } else if (passwordInput.value) {
         passwordInput.value.focus();
       }
@@ -655,7 +587,7 @@ const handleCreateUser = async () => {
     const wantsPassword = authType.value === 'password' || authType.value === 'both';
     const wantsPin = (authType.value === 'pin' || authType.value === 'both') && systemSettings.value.allow_pin;
     const passwordValue = newUser.value.password || '';
-    const pinValue = createPinDigits.value.join('');
+    const pinValue = createPinDigits.value;
 
     // Mode-specific client-side validation. Without this, "Both" + only one
     // input filled would silently fall back to that single credential at the
@@ -682,7 +614,7 @@ const handleCreateUser = async () => {
     // Reset form
     showCreateUser.value = false;
     newUser.value = { name: '', avatar: '', password: '', pin: '' };
-    createPinDigits.value = ['', '', '', ''];
+    createPinDigits.value = '';
     isAdminCheckbox.value = false;
     
   } catch (error) {


### PR DESCRIPTION
## Summary

- The SetCredentialsModal upgrade prompt rendered the PIN as a single wide `type=password` bar — visually inconsistent with the 4-box auto-advancing input used at signup, login, and in the profile panel.
- Pulled the duplicated 4-box markup + handlers into `frontend/components/ui/PinInput.vue` and wired all four sites to it. The composable refs collapse from `['','','','']` to plain strings; `.join('')` and array resets disappear.
- Display swaps `type=password` for a manual reveal: the just-typed digit shows for 1s before masking to a bullet, and typing in another box masks the previous one immediately — matches iOS/Android keypad UX so users can confirm what they pressed without ever leaving more than one digit visible at a time.

## Test plan

- [ ] Manual stack on `localhost:3000`: select a legacy account → credential upgrade modal shows 4-box PIN that auto-advances and reveals each digit briefly before masking.
- [ ] Signup: PIN tab on the create-user form behaves the same way.
- [ ] Login: 4-box PIN auto-focuses the first digit when the auth modal opens for a PIN-capable user.
- [ ] Profile (UserManagement): "Add PIN" / "Change PIN" panel still saves; Enter key submits.
- [ ] Existing e2e specs (`credential-flows.spec.js`, `pin-disabled-upgrade.spec.js`) pass — `data-testid` format unchanged.