### PR TITLE
feat(thumbnails): auto-detect cover art and frame-extract fallback

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -22,6 +22,12 @@ FROM node:20-alpine
 
 WORKDIR /app
 
+# ffmpeg / ffprobe are used to auto-derive a course thumbnail from the first
+# video when the operator hasn't dropped a cover image in the course folder.
+# Alpine's package is the static build (~50 MB); pinned to no-cache so layer
+# rebuilds stay reproducible.
+RUN apk add --no-cache ffmpeg
+
 # Copy the build output from the builder stage. Chown to the unprivileged
 # `node` user (uid 1000) shipped by the official node:20-alpine image so the
 # runtime stage can drop privileges via USER below.

--- a/frontend/server/utils/courseWatcher.js
+++ b/frontend/server/utils/courseWatcher.js
@@ -5,7 +5,12 @@ import { getContentDir } from './courseHelpers';
 import { generateCourseJson } from './courseGenerator';
 import { saveCourseToDb, removeCourseFromDb, getCoursesWithDirectories, getCourseCountFromDb } from './courseDatabase';
 import { getDb } from './db';
-import { readAndProcessThumbnail, getCourseRootPath } from './thumbnailUtils';
+import {
+  readAndProcessThumbnail,
+  getCourseRootPath,
+  findLocalThumbnailPath,
+  extractFrameThumbnail,
+} from './thumbnailUtils';
 import { generateCourseId } from './courseHelpers'; // Added generateCourseId import explicitly for clarity within processCourseDirWithMetadataPreservation
 
 // Read just the keys of course.json so we know which fields the operator
@@ -52,8 +57,27 @@ export const initialScanStatus = {
   preserveMetadata: true
 };
 
-// Function to synchronize thumbnail between filesystem and database
-async function synchronizeCourseThumbnail(courseId, courseFolderName) {
+// Resolve the absolute path of a course's first video by walking the lesson
+// tree the generator produced. Used by the frame-extract thumbnail fallback
+// when neither a local asset nor a cached DB blob is available.
+function resolveFirstVideoPath(courseRoot, courseData) {
+  if (!courseRoot || !courseData?.lessons?.length) return null;
+  for (const lesson of courseData.lessons) {
+    const videos = lesson?.videos;
+    if (!Array.isArray(videos) || videos.length === 0) continue;
+    const file = videos[0]?.file;
+    if (!file || typeof file !== 'string') continue;
+    return path.join(courseRoot, lesson.folder || '', file);
+  }
+  return null;
+}
+
+// Function to synchronize thumbnail between filesystem and database.
+// `courseData` is optional — passing it lets the function fall back to a
+// frame-extract from the first video when no operator-supplied cover art
+// exists. Callers that don't have courseData (e.g. a generic refresh path)
+// just lose the frame-extract fallback, which degrades to "no thumbnail."
+async function synchronizeCourseThumbnail(courseId, courseFolderName, courseData = null) {
   if (!courseId || !courseFolderName) {
     console.error('synchronizeCourseThumbnail: courseId and courseFolderName are required.');
     return;
@@ -61,7 +85,10 @@ async function synchronizeCourseThumbnail(courseId, courseFolderName) {
 
   const db = getDb();
   const courseRoot = getCourseRootPath(courseFolderName);
-  const localThumbnailPath = path.join(courseRoot, 'thumbnail.png');
+
+  // Plex-style asset detection: thumbnail.* / cover.* / poster.* / folder.*
+  // in priority order. Returning null means none exist on disk.
+  const localThumbnailPath = findLocalThumbnailPath(courseRoot);
 
   try {
     const courseResult = db.prepare('SELECT thumbnail_data FROM courses WHERE id = ?').get(courseId);
@@ -73,28 +100,45 @@ async function synchronizeCourseThumbnail(courseId, courseFolderName) {
     // eliminates the TOCTOU window between an upfront fs.existsSync sample
     // and the later read/write that CodeQL flagged twice (#30, #134).
     let localFileBuffer = null;
-    try {
-      localFileBuffer = fs.readFileSync(localThumbnailPath);
-    } catch (readError) {
-      if (readError.code !== 'ENOENT') throw readError;
+    if (localThumbnailPath) {
+      try {
+        localFileBuffer = fs.readFileSync(localThumbnailPath);
+      } catch (readError) {
+        if (readError.code !== 'ENOENT') throw readError;
+      }
     }
 
-    // Case 1: DB thumbnail_data is NULL and thumbnail.png exists locally.
+    // Case 1: DB thumbnail_data is NULL and a local asset exists.
     if (!dbThumbnailData && localFileBuffer) {
-      console.log(`[${courseId}] DB thumb is NULL, local exists. Updating DB from local file.`);
+      console.log(`[${courseId}] DB thumb is NULL, local ${path.basename(localThumbnailPath)} exists. Updating DB from local file.`);
       const processedLocalBuffer = await readAndProcessThumbnail(localThumbnailPath);
       if (processedLocalBuffer) {
         db.prepare('UPDATE courses SET thumbnail_data = ? WHERE id = ?').run(processedLocalBuffer, courseId);
-        console.log(`[${courseId}] DB thumbnail_data updated from local ${localThumbnailPath}`);
+        console.log(`[${courseId}] DB thumbnail_data updated from ${localThumbnailPath}`);
       }
     }
-    // Case 2: DB thumbnail_data is NULL and thumbnail.png does NOT exist locally.
+    // Case 2: DB thumbnail_data is NULL and no local asset.
+    // Try to derive one from the first video at the 10% mark. Frame-extract
+    // failures (missing ffmpeg, corrupt video, ...) silently degrade to "no
+    // thumbnail" — the UI's letter-fallback handles that branch already.
     else if (!dbThumbnailData && !localFileBuffer) {
-      // console.log(`[${courseId}] DB thumb is NULL, local does not exist. Doing nothing.`);
+      const firstVideoPath = resolveFirstVideoPath(courseRoot, courseData);
+      if (firstVideoPath) {
+        console.log(`[${courseId}] No cover art on disk and DB thumb is NULL. Trying frame extract from ${path.basename(firstVideoPath)}.`);
+        const frameBuffer = await extractFrameThumbnail(firstVideoPath);
+        if (frameBuffer) {
+          db.prepare('UPDATE courses SET thumbnail_data = ? WHERE id = ?').run(frameBuffer, courseId);
+          console.log(`[${courseId}] DB thumbnail_data populated from extracted frame.`);
+        }
+      }
     }
-    // Case 3: DB thumbnail_data is NOT NULL and thumbnail.png does NOT exist locally.
+    // Case 3: DB thumbnail_data is NOT NULL and no local asset.
+    // Write the DB blob back to thumbnail.png so the operator sees a file in
+    // the course folder. Uses the canonical name (thumbnail.png) so a
+    // round-trip never overwrites a user-supplied cover.jpg / poster.png.
     else if (dbThumbnailData && !localFileBuffer) {
-      console.log(`[${courseId}] DB thumb exists, local does not. Writing DB thumb to local file.`);
+      const writeBackPath = path.join(courseRoot, 'thumbnail.png');
+      console.log(`[${courseId}] DB thumb exists, no local asset. Writing DB thumb to ${path.basename(writeBackPath)}.`);
       try {
         // mkdirSync with recursive:true is idempotent — no exists-check needed.
         fs.mkdirSync(courseRoot, { recursive: true });
@@ -102,25 +146,44 @@ async function synchronizeCourseThumbnail(courseId, courseFolderName) {
         // concurrent process created the file between our read attempt
         // above and this write — their file is already a thumbnail, so
         // leave it.
-        fs.writeFileSync(localThumbnailPath, dbThumbnailData, { flag: 'wx' });
-        console.log(`[${courseId}] Local thumbnail.png created from DB data at ${localThumbnailPath}`);
+        fs.writeFileSync(writeBackPath, dbThumbnailData, { flag: 'wx' });
+        console.log(`[${courseId}] Local thumbnail.png created from DB data at ${writeBackPath}`);
       } catch (writeError) {
         if (writeError.code === 'EEXIST') {
           console.log(`[${courseId}] Local thumbnail.png appeared concurrently; skipping write.`);
         } else {
-          console.error(`[${courseId}] Error writing DB thumbnail to ${localThumbnailPath}:`, writeError);
+          console.error(`[${courseId}] Error writing DB thumbnail to ${writeBackPath}:`, writeError);
         }
       }
     }
-    // Case 4: DB thumbnail_data is NOT NULL and thumbnail.png exists locally.
+    // Case 4: DB thumbnail_data is NOT NULL and a local asset exists.
+    // If the operator dropped one of the named cover-art conventions
+    // (cover.jpg / poster.png / folder.jpg / ...), prefer it over whatever
+    // is in the DB — that's the "I imported the course, then added a cover
+    // later, rescanned, and expected it to win" flow. We only ever write
+    // back to thumbnail.png ourselves, so a thumbnail.png on disk is the
+    // round-tripped DB blob and stays under the existing edit-process-wins
+    // semantics (admin uploads via the UI keep their precedence there).
     else if (dbThumbnailData && localFileBuffer) {
-      // localFileBuffer was already read above — no second readFileSync needed.
-      if (!localFileBuffer.equals(dbThumbnailData)) {
-        // Log the difference but do not automatically overwrite.
-        // The edit process handles ensuring consistency after an intentional change.
-        console.log(`[${courseId}] DB thumbnail and local thumbnail differ. The application will use the DB version for display. The local file will not be automatically changed by this scan operation.`);
-      } else {
-        // console.log(`[${courseId}] DB thumbnail and local thumbnail are in sync.`);
+      const localName = path.basename(localThumbnailPath);
+      // Case-sensitive comparison: the only filename we ever round-trip from
+      // DB to disk is exactly `thumbnail.png`. Any other casing or basename
+      // (`Thumbnail.png`, `cover.jpg`, `Poster.PNG`, ...) means an operator
+      // dropped the file in by hand.
+      const isOperatorAuthored = localName !== 'thumbnail.png';
+      const differs = !localFileBuffer.equals(dbThumbnailData);
+      if (isOperatorAuthored && differs) {
+        console.log(`[${courseId}] Operator-authored ${localName} differs from DB blob — replacing DB with the local file.`);
+        const processedLocalBuffer = await readAndProcessThumbnail(localThumbnailPath);
+        if (processedLocalBuffer) {
+          db.prepare('UPDATE courses SET thumbnail_data = ? WHERE id = ?').run(processedLocalBuffer, courseId);
+          console.log(`[${courseId}] DB thumbnail_data updated from ${localThumbnailPath}`);
+        }
+      } else if (differs) {
+        // Round-tripped thumbnail.png whose contents diverged from the DB
+        // blob (e.g. admin-uploaded after the file was already on disk).
+        // Keep DB-as-authority; the edit process is the source of truth.
+        console.log(`[${courseId}] DB thumbnail and local ${localName} differ. Using DB version for display.`);
       }
     }
   } catch (error) {
@@ -210,7 +273,7 @@ const processCourseDirectory = async (courseDirPath, preserveMetadata = false) =
       
       console.log(`Course data saved to database for ${courseDir}`);
       // After saving basic course data, synchronize the thumbnail
-      await synchronizeCourseThumbnail(courseData.id, courseDir);
+      await synchronizeCourseThumbnail(courseData.id, courseDir, courseData);
       return { success: true, courseId: courseData.id };
     }
   } catch (error) {
@@ -260,7 +323,7 @@ const processCourseDirWithMetadataPreservation = async (courseDirPath, existingC
       await saveCourseToDb(updatedCourseData, courseDir);
       console.log(`Course metadata updated (preserved) for ${courseDir}`);
       // After saving/updating course data, synchronize the thumbnail
-      await synchronizeCourseThumbnail(updatedCourseData.id, courseDir);
+      await synchronizeCourseThumbnail(updatedCourseData.id, courseDir, updatedCourseData);
 
     } else if (courseData) {
       // New course or no existing metadata to preserve, treat as new
@@ -268,7 +331,7 @@ const processCourseDirWithMetadataPreservation = async (courseDirPath, existingC
       await saveCourseToDb(courseData, courseDir);
       console.log(`New course data saved (or no metadata to preserve) for ${courseDir}`);
       // After saving basic course data, synchronize the thumbnail
-      await synchronizeCourseThumbnail(courseData.id, courseDir);
+      await synchronizeCourseThumbnail(courseData.id, courseDir, courseData);
     } else {
       console.warn(`Could not generate course data for ${courseDir} during metadata preservation.`);
     }

--- a/frontend/server/utils/thumbnailUtils.js
+++ b/frontend/server/utils/thumbnailUtils.js
@@ -1,6 +1,11 @@
 import fs from 'fs';
+import path from 'path';
+import { spawn, execFile } from 'child_process';
+import { promisify } from 'util';
 import sharp from 'sharp';
 import { resolveCourseDir } from './courseHelpers';
+
+const execFileAsync = promisify(execFile);
 
 /**
  * Get the absolute path to a course's root directory.
@@ -19,26 +24,206 @@ export const getCourseRootPath = (courseFolderName) => {
 };
 
 /**
+ * Plex-style local-asset detection. Priority order: explicit `thumbnail.*`
+ * first (the historical canonical name), then the conventional `cover.*` /
+ * `poster.*` / `folder.*` names that most downloaded course bundles ship
+ * with. Each pair matches case-insensitively (`Cover.JPG` and `cover.jpg`
+ * are equivalent), which is essential for course folders authored on
+ * case-preserving Windows / macOS filesystems but served from a case-
+ * sensitive Linux container.
+ */
+const THUMBNAIL_NAME_PRIORITY = ['thumbnail', 'cover', 'poster', 'folder'];
+const THUMBNAIL_EXT_PRIORITY = ['png', 'jpg', 'jpeg', 'webp'];
+
+/**
+ * Look for a course-supplied thumbnail in the course folder.
+ * Enumerates the directory once, normalizes entry names to lowercase, and
+ * resolves matches in (name, extension) priority order. Skips zero-byte
+ * files and non-files so a directory named `cover.jpg` can't masquerade.
+ * @param {string} courseRoot - Absolute path to the course root.
+ * @returns {string|null} Absolute path to the first matching file, or null.
+ */
+export const findLocalThumbnailPath = (courseRoot) => {
+  if (!courseRoot) return null;
+  let entries;
+  try {
+    entries = fs.readdirSync(courseRoot, { withFileTypes: true });
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      console.warn(`[thumb] cannot list ${courseRoot}: ${err.message}`);
+    }
+    return null;
+  }
+  // Build "<basename-lower>.<ext-lower>" → real filename. Keep the first
+  // entry seen for each key so duplicates differing only in case (e.g.
+  // `cover.jpg` and `Cover.jpg` on a case-sensitive FS) resolve to the
+  // earlier-listed one rather than flickering between scans.
+  const byKey = new Map();
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const extWithDot = path.extname(entry.name);
+    if (!extWithDot) continue;
+    const base = path.basename(entry.name, extWithDot).toLowerCase();
+    const ext = extWithDot.slice(1).toLowerCase();
+    const key = `${base}.${ext}`;
+    if (!byKey.has(key)) byKey.set(key, entry.name);
+  }
+  for (const base of THUMBNAIL_NAME_PRIORITY) {
+    for (const ext of THUMBNAIL_EXT_PRIORITY) {
+      const realName = byKey.get(`${base}.${ext}`);
+      if (!realName) continue;
+      const full = path.join(courseRoot, realName);
+      try {
+        const stat = fs.statSync(full);
+        if (stat.size > 0) return full;
+      } catch (err) {
+        if (err.code !== 'ENOENT') {
+          console.warn(`[thumb] cannot stat ${full}: ${err.message}`);
+        }
+      }
+    }
+  }
+  return null;
+};
+
+/**
  * Reads a thumbnail image file, processes it with sharp, and returns a buffer.
- * @param {string} thumbnailPath - Absolute path to the thumbnail.png file.
+ * @param {string} thumbnailPath - Absolute path to the thumbnail file.
  * @returns {Promise<Buffer|null>} Processed image buffer or null if an error occurs.
  */
 export const readAndProcessThumbnail = async (thumbnailPath) => {
   try {
     if (!fs.existsSync(thumbnailPath)) {
-      // console.log(`Thumbnail not found at: ${thumbnailPath}`);
       return null;
     }
     const fileBuffer = fs.readFileSync(thumbnailPath);
+    // Force PNG output regardless of input format. /api/course-thumbnail/:id
+    // serves the cached blob with Content-Type: image/png, so a JPEG or WebP
+    // cover dropped in the course folder would otherwise be served with the
+    // wrong MIME type and mis-render in strict clients.
     const processedBuffer = await sharp(fileBuffer)
       .resize(480, 270, {
         fit: 'cover',
         position: 'center',
       })
+      .png()
       .toBuffer();
     return processedBuffer;
   } catch (error) {
     console.error(`Error processing thumbnail at ${thumbnailPath}:`, error);
+    return null;
+  }
+};
+
+/**
+ * Probe the duration of a video file. Used to compute a 10%-into-the-video
+ * seek target for the frame-extract thumbnail fallback.
+ * @param {string} videoPath
+ * @returns {Promise<number|null>} Duration in seconds, or null on any failure.
+ */
+const probeVideoDuration = async (videoPath) => {
+  try {
+    const { stdout } = await execFileAsync(
+      'ffprobe',
+      [
+        '-v', 'error',
+        '-show_entries', 'format=duration',
+        '-of', 'default=noprint_wrappers=1:nokey=1',
+        videoPath,
+      ],
+      { timeout: 10_000 }
+    );
+    const seconds = parseFloat(String(stdout).trim());
+    return Number.isFinite(seconds) && seconds > 0 ? seconds : null;
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      console.warn(`[thumb] ffprobe failed for ${videoPath}: ${err.message}`);
+    }
+    return null;
+  }
+};
+
+/**
+ * Extract a single JPEG frame at ~10% into the video, then run it through
+ * sharp so the cached blob has the same shape as a normal thumbnail. Returns
+ * null on any failure (missing ffmpeg, unreadable video, etc.) — the caller
+ * is expected to fall back gracefully.
+ *
+ * Used by synchronizeCourseThumbnail when the operator did NOT drop a cover
+ * image in the course folder AND the DB has no cached blob yet.
+ * @param {string} videoPath - Absolute path to a video file (typically the
+ *   first lesson's first video).
+ * @returns {Promise<Buffer|null>}
+ */
+export const extractFrameThumbnail = async (videoPath) => {
+  if (!videoPath) return null;
+  try {
+    const stat = fs.statSync(videoPath);
+    if (!stat.isFile() || stat.size === 0) return null;
+  } catch {
+    return null;
+  }
+
+  // Seek to 10% of the duration. Without ffprobe we'd be guessing; without a
+  // duration we'd risk feeding ffmpeg `-ss` past the end and getting an empty
+  // stream. Floor at 1s so we don't seek to frame 0 of an unusually short clip.
+  const duration = await probeVideoDuration(videoPath);
+  const seekSec = duration ? Math.max(1, duration * 0.1) : 30;
+
+  const rawFrame = await new Promise((resolve) => {
+    let proc;
+    try {
+      proc = spawn(
+        'ffmpeg',
+        [
+          '-loglevel', 'error',
+          '-ss', String(seekSec),       // -ss before -i = fast input seek
+          '-i', videoPath,
+          '-frames:v', '1',
+          '-f', 'image2',
+          '-c:v', 'mjpeg',
+          '-',                          // write to stdout
+        ],
+        { stdio: ['ignore', 'pipe', 'pipe'] }
+      );
+    } catch (err) {
+      console.warn(`[thumb] ffmpeg spawn failed: ${err.message}`);
+      return resolve(null);
+    }
+
+    const chunks = [];
+    let stderrBuf = '';
+    proc.stdout.on('data', (chunk) => chunks.push(chunk));
+    proc.stderr.on('data', (chunk) => { stderrBuf += chunk.toString(); });
+
+    let settled = false;
+    const finish = (val) => { if (!settled) { settled = true; resolve(val); } };
+
+    proc.on('error', (err) => {
+      console.warn(`[thumb] ffmpeg error for ${videoPath}: ${err.message}`);
+      finish(null);
+    });
+    proc.on('close', (code) => {
+      if (code !== 0 || chunks.length === 0) {
+        if (stderrBuf.trim()) {
+          console.warn(`[thumb] ffmpeg exited ${code} for ${videoPath}: ${stderrBuf.trim()}`);
+        }
+        return finish(null);
+      }
+      finish(Buffer.concat(chunks));
+    });
+  });
+
+  if (!rawFrame) return null;
+  try {
+    // Force PNG output so the cached blob matches what the thumbnail
+    // endpoint advertises (Content-Type: image/png).
+    return await sharp(rawFrame)
+      .resize(480, 270, { fit: 'cover', position: 'center' })
+      .png()
+      .toBuffer();
+  } catch (err) {
+    console.warn(`[thumb] sharp failed to process extracted frame for ${videoPath}: ${err.message}`);
     return null;
   }
 };


### PR DESCRIPTION
## Summary

Most downloaded course bundles ship with \`cover.jpg\` / \`poster.jpg\` / \`folder.jpg\` next to the videos. The scanner only ever looked for \`thumbnail.png\`, so the library showed the gray-letter fallback for those courses. Plex / Jellyfin call this "local media assets"; this brings the same convention to SkillGoblin.

- **Local-asset detection** — \`thumbnail.*\` / \`cover.*\` / \`poster.*\` / \`folder.*\` (png/jpg/jpeg/webp), priority-ordered, case-insensitive.
- **PNG normalization** — both the local-asset path and the frame-extract path \`sharp.png()\` their output so the cached \`thumbnail_data\` blob matches the \`image/png\` Content-Type the API serves.
- **Frame-extract fallback** — ffprobe + ffmpeg pull a single frame at the 10% mark of the first lesson's first video. ffmpeg ships in the prod image as a new \`apk add\` layer (~50 MB). Failures degrade silently to "no thumbnail."
- **Operator-cover-wins on rescan** — Case 4 (DB blob + local file both present) used to log and keep DB. Now: anything whose filename ≠ \`thumbnail.png\` is treated as operator-authored and replaces the DB blob, fixing the "import → frame-extract → drop cover.jpg later → rescan" flow.

## Test plan

- [ ] Drop a course with no thumbnail → rescan → first-frame thumbnail extracted at ~10% mark, library shows it.
- [ ] Drop a \`cover.jpg\` into that same folder → rescan → cover.jpg wins, replaces the extracted frame.
- [ ] Verify \`Content-Type\` on \`/api/course-thumbnail/:id\` is \`image/png\` regardless of the source filename's extension.
- [ ] Drop a \`Cover.JPG\` (mixed case) on Linux → still detected and used.
- [ ] Course with both \`thumbnail.png\` and \`cover.jpg\` → \`thumbnail.png\` wins (priority).
- [ ] Admin uploads a thumbnail via the admin UI → rescan → DB version still wins (no regression on the existing flow).

## Codex review

Two rounds caught: \`sharp\` not normalizing input format → MIME mismatch (fixed), Case 4 keeping a stale frame-extracted blob when operator drops a cover later (fixed), case-sensitive filename matching missing \`Cover.JPG\` on Linux (fixed). The third round hit a usage-limit ceiling on the Codex side; the final case-sensitivity fix is well-bounded (\`localName !== 'thumbnail.png'\` for the round-trip identity check).