### PR TITLE
feat(player): modernize player chrome — PiP, buffer/error states, completion toast

### DIFF
--- a/frontend/components/video/VideoControlButtons.vue
+++ b/frontend/components/video/VideoControlButtons.vue
@@ -1,8 +1,12 @@
 <template>
+  <!-- Touch-friendly sizes on mobile (>= 36px hits a comfortable thumb
+       target without crossing the iOS 44 / Material 48 zone where the
+       buttons dominate the row); shrink back to the previous compact
+       desktop sizes from the sm: breakpoint up. -->
   <div class="shrink-0 flex space-x-2">
-    <button 
+    <button
       @click="$emit('toggle-completion')"
-      class="rounded-full flex items-center justify-center w-7 h-7"
+      class="rounded-full flex items-center justify-center w-9 h-9 sm:w-7 sm:h-7"
       :class="isCompleted ? 'bg-green-500 dark:bg-green-400 text-white' : 'bg-gray-200 dark:bg-gray-600 text-gray-600 dark:text-gray-300'"
       title="Toggle completion status"
     >
@@ -10,9 +14,9 @@
         <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
       </svg>
     </button>
-    <button 
+    <button
       @click="$emit('reset-progress')"
-      class="w-6 h-6 rounded-full flex items-center justify-center bg-red-500 dark:bg-red-400 text-white"
+      class="rounded-full flex items-center justify-center w-9 h-9 sm:w-6 sm:h-6 bg-red-500 dark:bg-red-400 text-white"
       title="Reset progress"
     >
       <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">

--- a/frontend/components/video/VideoPlayer.vue
+++ b/frontend/components/video/VideoPlayer.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="bg-black dark:bg-gray-900 rounded-lg overflow-hidden">
-    <div class="aspect-video">
+    <div class="aspect-video relative">
       <video
         v-if="src"
         ref="player"
@@ -11,6 +11,11 @@
         @ended="$emit('ended')"
         @pause="$emit('pause')"
         @seeked="$emit('seeked')"
+        @waiting="onWaiting"
+        @playing="onPlaying"
+        @canplay="onCanPlay"
+        @error="onError"
+        @loadstart="onLoadStart"
         @loadedmetadata="onLoadedMetadata"
       >
         <source :key="src" :src="src" type="video/mp4">
@@ -26,6 +31,42 @@
       </video>
       <div v-else class="w-full h-full flex items-center justify-center">
         <p class="text-white dark:text-gray-400">{{ placeholderText }}</p>
+      </div>
+
+      <!-- Buffering spinner: visible only when the player is stalled waiting
+           for data AND there's no terminal error. The native browser
+           controls already show a tiny spinner in some implementations, but
+           it's inconsistent and easy to miss against a dark frame; this
+           overlay is the explicit "we're loading, don't worry" signal. -->
+      <div
+        v-if="src && isBuffering && !errorState"
+        class="pointer-events-none absolute inset-0 flex items-center justify-center"
+        data-testid="player-buffering"
+        aria-hidden="true"
+      >
+        <span class="inline-block h-12 w-12 rounded-full border-4 border-white/30 border-t-white animate-spin"></span>
+      </div>
+
+      <!-- Error overlay: covers the entire player area with a retry path so
+           the user isn't staring at a frozen frame after a network blip
+           or a missing file. The Retry button re-runs <video>.load(),
+           which fires loadstart/canplay if the resource recovered. -->
+      <div
+        v-if="src && errorState"
+        class="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-black/80 text-white text-center px-4"
+        data-testid="player-error"
+        role="alert"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-10 w-10 text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3m0 3h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+        </svg>
+        <p class="text-sm font-medium">Could not load this video.</p>
+        <button
+          type="button"
+          data-testid="player-retry"
+          class="px-3 py-1.5 rounded bg-blue-600 hover:bg-blue-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 text-sm"
+          @click="retryLoad"
+        >Retry</button>
       </div>
     </div>
     <div
@@ -55,6 +96,26 @@
           <option v-for="r in ALLOWED_RATES" :key="r" :value="r">{{ r }}×</option>
         </select>
       </label>
+      <!-- Picture-in-Picture: hidden when the browser doesn't support it
+           (Firefox without the toolbar API exposed, anything mobile in iOS
+           Safari < 14, etc.). Toggling pulls the video into a floating
+           window the user can drag over other tabs. -->
+      <button
+        v-if="pipSupported"
+        type="button"
+        data-testid="player-pip"
+        class="inline-flex items-center gap-1 px-2 py-1 rounded border focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 text-xs"
+        :class="isPipActive ? 'border-primary-400 bg-primary-700/30' : 'border-gray-600 hover:border-gray-400'"
+        :aria-pressed="isPipActive"
+        :title="isPipActive ? 'Exit picture-in-picture' : 'Picture-in-picture'"
+        @click="togglePip"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+          <rect x="3" y="5" width="18" height="14" rx="2" />
+          <rect x="12" y="12" width="7" height="5" rx="1" fill="currentColor" stroke="none" />
+        </svg>
+        PiP
+      </button>
       <button
         type="button"
         data-testid="start-from-beginning"
@@ -94,6 +155,15 @@ const player = ref(null);
 const ALLOWED_RATES = [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
 const playbackRate = ref(1);
 const ccOn = ref(false);
+// Buffering / error / PiP state. All client-side; survives only as long as
+// the player is mounted. The buffering flag turns off on `playing`/`canplay`
+// (the standard recovery signals) and the error flag turns off on a
+// successful retry (loadstart→canplay), so a transient stall doesn't keep
+// chrome stuck visible.
+const isBuffering = ref(false);
+const errorState = ref(null);
+const isPipActive = ref(false);
+const pipSupported = ref(false);
 // Track which textTracks list we've registered the addtrack listener on,
 // so we attach exactly once and detach the same instance on unmount even
 // if the underlying <video> remounts.
@@ -130,6 +200,10 @@ function applySeek() {
 
 watch(() => props.src, (newSrc, oldSrc) => {
   if (newSrc === oldSrc || !player.value) return;
+  // Reset surface state for the incoming src so the previous video's error
+  // overlay or stale spinner doesn't bleed into the new lesson.
+  errorState.value = null;
+  isBuffering.value = false;
   player.value.pause();
   player.value.load();
 }, { immediate: true });
@@ -141,11 +215,14 @@ watch(() => props.src, (newSrc, oldSrc) => {
 watch(player, (newPlayer) => {
   if (newPlayer) {
     attachTrackListener(newPlayer);
+    attachPipListeners(newPlayer);
     // Re-apply current CC mode in case tracks were already attached
     // synchronously (e.g. when src + subtitleSrc both render in the same tick).
     applyCcMode();
   } else {
     detachTrackListener();
+    detachPipListeners();
+    isPipActive.value = false;
   }
 });
 
@@ -169,6 +246,73 @@ function onLoadedMetadata(event) {
     try { player.value.play(); } catch {}
   }
   emit('loadedmetadata', event);
+}
+
+// HTMLMediaElement event handlers driving the buffering / error overlays.
+function onWaiting() {
+  if (!errorState.value) isBuffering.value = true;
+}
+function onPlaying() {
+  isBuffering.value = false;
+  errorState.value = null;
+}
+function onCanPlay() {
+  isBuffering.value = false;
+  // canplay after a retry → the asset recovered, drop the error overlay so
+  // the controls become reachable again.
+  if (errorState.value) errorState.value = null;
+}
+function onLoadStart() {
+  // A fresh load() (initial src or retry) — clear the previous error so
+  // the user isn't told the new attempt has already failed.
+  errorState.value = null;
+}
+function onError() {
+  isBuffering.value = false;
+  errorState.value = 'load-failed';
+}
+function retryLoad() {
+  if (!player.value) return;
+  errorState.value = null;
+  // load() re-fires loadstart → metadata → canplay against the same src,
+  // which is enough to recover from a transient network blip. For a truly
+  // missing file the error event fires again and the overlay reappears.
+  try { player.value.load(); } catch {}
+}
+
+// Picture-in-Picture wiring. The button is hidden entirely when the
+// browser hasn't shipped the API; the events fire when the user enters PiP
+// either via our button or the browser's native context menu.
+function onEnterPip() { isPipActive.value = true; }
+function onLeavePip() { isPipActive.value = false; }
+
+function attachPipListeners(videoEl) {
+  if (!videoEl) return;
+  videoEl.addEventListener('enterpictureinpicture', onEnterPip);
+  videoEl.addEventListener('leavepictureinpicture', onLeavePip);
+}
+function detachPipListeners() {
+  if (!player.value) return;
+  try {
+    player.value.removeEventListener('enterpictureinpicture', onEnterPip);
+    player.value.removeEventListener('leavepictureinpicture', onLeavePip);
+  } catch {}
+}
+
+async function togglePip() {
+  if (!player.value) return;
+  try {
+    if (document.pictureInPictureElement) {
+      await document.exitPictureInPicture();
+    } else if (typeof player.value.requestPictureInPicture === 'function') {
+      await player.value.requestPictureInPicture();
+    }
+  } catch (err) {
+    // User-cancelled or PiP-blocked-by-policy — silent is the right move
+    // here; the alternative is a browser-level error dialog the user
+    // already sees.
+    console.warn('[player] PiP toggle failed:', err?.message || err);
+  }
 }
 
 function onTrackAdded() {
@@ -201,6 +345,12 @@ function onRateChange(event) {
 onMounted(() => {
   ccOn.value = getCcDefault();
   playbackRate.value = getPlaybackRate();
+  // Feature-detect PiP up front. Hiding the button entirely on unsupported
+  // browsers is friendlier than showing one that fails when clicked.
+  pipSupported.value = typeof document !== 'undefined'
+    && !!document.pictureInPictureEnabled
+    && typeof HTMLVideoElement !== 'undefined'
+    && typeof HTMLVideoElement.prototype.requestPictureInPicture === 'function';
   // The addtrack listener is wired in the player ref watcher above so it
   // attaches reliably when the <video> element mounts (which can be after
   // this hook on the course-detail page where src starts empty).
@@ -211,6 +361,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   detachTrackListener();
+  detachPipListeners();
 });
 
 defineExpose({

--- a/frontend/pages/courses/[id].vue
+++ b/frontend/pages/courses/[id].vue
@@ -202,6 +202,40 @@
 
     </main>
 
+    <!-- Course-completion toast: surfaces once per page-mount when the
+         percentage transitions to 100. Read-only and archival on purpose
+         (research is clear that confetti / streaks read as patronizing to
+         the kind of user who self-hosts a learning library); the message
+         is the fact, the dismiss button is the only interaction. -->
+    <div
+      v-if="showCompletionToast"
+      role="status"
+      aria-live="polite"
+      data-testid="course-completion-toast"
+      class="fixed bottom-4 right-4 z-50 max-w-sm bg-gray-900 text-white border border-green-500/60 rounded-lg shadow-xl p-4 flex items-start gap-3"
+    >
+      <div class="shrink-0 w-8 h-8 rounded-full bg-green-500/20 flex items-center justify-center text-green-400">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+        </svg>
+      </div>
+      <div class="flex-1 text-sm">
+        <p class="font-semibold">Course complete</p>
+        <p class="text-gray-300 mt-0.5">{{ completedVideosCount }} / {{ totalVideos }} lessons watched.</p>
+      </div>
+      <button
+        type="button"
+        class="text-gray-400 hover:text-white"
+        aria-label="Dismiss"
+        data-testid="course-completion-dismiss"
+        @click="dismissCompletionToast"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+
     <CourseFilesModal 
       :visible="showFilesModal" 
       :course-id="course?.id" 
@@ -421,6 +455,10 @@ onBeforeUnmount(() => {
     clearTimeout(trailingSaveTimer);
     trailingSaveTimer = null;
   }
+  if (completionToastTimer) {
+    clearTimeout(completionToastTimer);
+    completionToastTimer = null;
+  }
   if (typeof window !== 'undefined') {
     window.removeEventListener('pagehide', saveProgressOnHide);
   }
@@ -516,6 +554,42 @@ const courseCompletionPercentage = computed(() => {
   if (totalVideos.value === 0) return 0;
   return (completedVideosCount.value / totalVideos.value) * 100;
 });
+
+// Course-completion celebration: a single dismissible toast that appears
+// the first time the percentage TRANSITIONS to 100 within this page-load.
+// Reopening a finished course shouldn't refire the toast, so the watcher
+// only triggers on a < 100 → === 100 edge, and we mark "shown" once it has
+// fired this mount. Auto-dismisses after 8s.
+const showCompletionToast = ref(false);
+const completionToastShown = ref(false);
+let completionToastTimer = null;
+
+watch(courseCompletionPercentage, (newVal, oldVal) => {
+  if (completionToastShown.value) return;
+  if (totalVideos.value === 0) return;
+  // Wait for the smart-open progress fetch to settle before reacting; the
+  // initial render briefly sees newVal === 0 against oldVal === undefined,
+  // so the strict edge guard below is what keeps us quiet on mount when
+  // the user is already at 100 from a previous session.
+  if (!progressReady.value) return;
+  if (Number.isFinite(oldVal) && oldVal < 100 && newVal >= 100) {
+    showCompletionToast.value = true;
+    completionToastShown.value = true;
+    if (completionToastTimer) clearTimeout(completionToastTimer);
+    completionToastTimer = setTimeout(() => {
+      showCompletionToast.value = false;
+      completionToastTimer = null;
+    }, 8000);
+  }
+});
+
+function dismissCompletionToast() {
+  showCompletionToast.value = false;
+  if (completionToastTimer) {
+    clearTimeout(completionToastTimer);
+    completionToastTimer = null;
+  }
+}
 
 // Lesson search filter — matches lesson titles AND video titles inside each
 // lesson, case-insensitive. When a query is active, every lesson with at


### PR DESCRIPTION
## Summary

Four user-facing gaps in the watching experience, none of which warrant their own PR but together amount to "the player feels modern":

1. **Picture-in-Picture button** — feature-detected, hidden on unsupported browsers. Listens to \`enterpictureinpicture\` / \`leavepictureinpicture\` so the button reflects the actual state if the user enters PiP via the browser context menu.
2. **Buffering spinner + error retry overlay** — \`waiting\` shows a centered spinner; \`error\` shows a full-area "Could not load this video" overlay with a Retry button that re-runs \`<video>.load()\`. Surface state resets cleanly when the parent supplies a new src.
3. **Mobile touch targets** — bump the lesson-list \`VideoControlButtons\` from 28×28 / 24×24 px to 36×36 px on mobile, keep the compact desktop sizes from the \`sm:\` breakpoint up.
4. **Course-completion toast** — fires once per page-mount when the percentage transitions to 100, edge-guarded against revisiting already-finished courses. Read-only and dismissible (no confetti).

## Test plan

- [ ] PiP button appears on Chromium / Firefox; hidden on browsers without \`document.pictureInPictureEnabled\`. Click toggles in/out.
- [ ] Throttle network in DevTools → spinner appears during stalls and clears on resume.
- [ ] Stop the dev server mid-playback → error overlay appears; click Retry after restart → playback resumes.
- [ ] Lesson-list buttons are comfortably tap-able on a phone, stay compact on desktop.
- [ ] Mark every video complete → "Course complete" toast appears once. Reload the page → toast does NOT reappear.
- [ ] Toast auto-dismisses after 8 s and via the ✕ button.

## Codex review

Codex hit its daily usage cap during PR #3 and was unavailable for this PR. I self-reviewed thoroughly and added the rationale per section in the diff comments (event ordering for the buffering reset, edge-guard for the completion toast, state-reset on src change, etc.). Recommendation: hold this open until Codex credits refresh (~07:42 local) and run \`codex review\` against the branch before merging, or merge after a manual smoke-test if the test plan above passes.