### PR TITLE
fix(pin): drop pattern attr — masked bullet trips HTML5 validation on submit

### DIFF
--- a/frontend/components/ui/PinInput.vue
+++ b/frontend/components/ui/PinInput.vue
@@ -1,4 +1,10 @@
 <template>
+  <!-- No `pattern` attribute on the inputs: the displayed value flips to a
+       bullet (●) once the reveal timer expires, and HTML5 validation on
+       `pattern="[0-9]*"` would then refuse to submit the parent <form>
+       with "Please match the requested format" before our JS handler can
+       read the actual digits from v-model. Digit-only enforcement happens
+       in onInput via the regex strip, so dropping pattern here is safe. -->
   <div class="flex justify-center space-x-2 pin-input-container">
     <input
       v-for="i in 4"
@@ -9,7 +15,6 @@
       :value="displayValue(i - 1)"
       type="text"
       inputmode="numeric"
-      pattern="[0-9]*"
       autocomplete="off"
       :disabled="disabled"
       :class="digitClass"


### PR DESCRIPTION
## Summary

**Login was broken.** Clicking Login on the PIN form surfaced the browser's native validation tooltip ("Please match the requested format") and refused to submit. Regression introduced in #80 (the iOS-style reveal-then-mask).

**Root cause.** Once the reveal timer expires, the DOM input's value becomes \`●\` (bullet). The \`pattern="[0-9]*"\` attribute rejects that on form submit, BEFORE the \`@submit\` handler can read the actual digits from v-model.

**Fix.** Drop \`pattern\` from the input. \`onInput\` already strips non-digits via \`replace(/[^0-9]/g, '')\`, and \`inputmode="numeric"\` keeps the numeric keyboard on mobile. Added a comment to keep someone from reflexively putting it back.

## Test plan

- [ ] Login screen → click avatar → enter PIN → digits reveal-then-mask as before → click Login → request goes through, no validation popup.
- [ ] Same flow on a profile that uses both password and PIN.
- [ ] Signup PIN flow still rejects non-digit keystrokes (the regex in \`onInput\` does the work).