### PR TITLE
feat(docker): auto-repair volume permissions on start

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -26,7 +26,11 @@ WORKDIR /app
 # video when the operator hasn't dropped a cover image in the course folder.
 # Alpine's package is the static build (~50 MB); pinned to no-cache so layer
 # rebuilds stay reproducible.
-RUN apk add --no-cache ffmpeg
+#
+# su-exec is the Alpine-native ~20 KB equivalent of gosu — used by the
+# entrypoint to drop from root to `node` after fixing volume ownership
+# on first start (see frontend/scripts/entrypoint.sh).
+RUN apk add --no-cache ffmpeg su-exec
 
 # Copy the build output from the builder stage. Chown to the unprivileged
 # `node` user (uid 1000) shipped by the official node:20-alpine image so the
@@ -47,21 +51,41 @@ ENV PORT=3000
 ENV NODE_ENV=production
 
 # Create necessary directories owned by `node`. /app/data is the bind-mount
-# target for the host's data volume — the host directory must be writable
-# by uid 1000 (host: `chown -R 1000:1000 ./data` if migrating from a
-# pre-USER-drop install where files were created by root in the container).
+# target for the host's data volume; the entrypoint will repair its
+# ownership on each start when the bind-mount comes in with the wrong uid
+# (typically the case when upgrading from a pre-uid-1000 image where files
+# were created as root inside the container).
 RUN mkdir -p /app/data/database && chown -R node:node /app/data
 
 EXPOSE 3000
 
-# Drop root before running the app — addresses Trivy/CodeQL DS-0002.
-USER node
+# Note: a `USER node` directive is intentionally NOT set here. The
+# entrypoint starts as root (PID 1) just long enough to chown the bind-
+# mounted data/database and data/branding directories to uid 1000, then
+# drops to the `node` user via `su-exec` before launching Node. The
+# Node.js process — the only thing on the network — never runs as root.
+#
+# This trades the static `USER node` posture for an automatic upgrade
+# path: operators moving from a pre-uid-1000 image no longer have to
+# `sudo chown -R 1000:1000 ./data` on the host before the new container
+# can open its database. Operators who'd rather manage perms themselves
+# can override the runtime user (compose: `user: 1000:1000`); the
+# entrypoint detects that case and skips the root branch entirely.
+#
+# This pattern is shared by the official postgres / redis / nextcloud
+# images for the same reason. CodeQL DS-0002 / Trivy
+# DKL-DI-0006 will flag this as "missing USER" — the trade-off is
+# documented and intentional.
 
 # Liveness probe — uses the same /api/users endpoint and shape that
 # docker-compose.test.yml's healthcheck uses.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD wget -qO- http://127.0.0.1:3000/api/users >/dev/null 2>&1 || exit 1
 
-# Start the server (entrypoint script maps APP_* -> NUXT_PUBLIC_BRANDING_*
-# then exec's node .output/server/index.mjs)
-CMD ["/usr/local/bin/skillgoblin-entrypoint.sh"]
+# ENTRYPOINT + CMD split: the entrypoint always runs (repairs volume
+# perms, drops to `node`, maps APP_* -> NUXT_PUBLIC_BRANDING_*) and then
+# exec's whatever the CMD is. That way a `docker run image bash` or
+# compose `command: <something>` override still gets the privilege drop
+# instead of running as root.
+ENTRYPOINT ["/usr/local/bin/skillgoblin-entrypoint.sh"]
+CMD ["node", ".output/server/index.mjs"]

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -35,6 +35,11 @@ services:
       # in sync with PW_ADMIN_NAME / PW_ADMIN_PASSWORD on the tests service.
       - ADMIN_NAME=root
       - ADMIN_PASSWORD=TestAdminPass!
+      # Skip the entrypoint's volume-ownership repair pass — branding and
+      # content below are bind-mounted from tracked repo fixtures, and a
+      # recursive chown to uid 1000 would dirty the working tree on the
+      # host. Privilege drop to `node` still happens.
+      - SKILLGOBLIN_SKIP_PERM_REPAIR=1
     volumes:
       # /app/data is a fresh tmpfs on every run. Long-form is required so
       # we can set mode=1777 — the prod image runs as the unprivileged

--- a/frontend/scripts/entrypoint.sh
+++ b/frontend/scripts/entrypoint.sh
@@ -1,25 +1,89 @@
 #!/bin/sh
-# Container entrypoint — maps operator-facing APP_* env vars onto Nuxt's
-# native NUXT_PUBLIC_BRANDING_* runtime-config override env vars BEFORE
-# starting the node server.
+# Container entrypoint. Two responsibilities, in order:
 #
-# Background: nuxt.config.js declares runtimeConfig.public.branding with
-# hardcoded SkillGoblin defaults so that Docker BUILD time (when 'npm run
-# build' runs in Dockerfile.prod) doesn't bake operator env into the
-# bundle — at build time, compose 'environment:' values do not exist.
+#  1. (root pass) Repair host bind-mount ownership and drop privileges.
+#     Runs only when the container started as root, which is the default
+#     for our image. Bounded to /app/data/database and /app/data/branding
+#     because they need write access; /app/data/content is intentionally
+#     left alone since read access is sufficient and recursive chown of a
+#     potentially huge content folder on every start would be pathological.
+#     After fixup, su-exec re-runs this same script as the `node` user
+#     (uid 1000), which falls through to the second pass below.
 #
-# Nuxt 3 supports env-driven overrides of runtimeConfig at server startup
-# via env vars matching the config structure (e.g. NUXT_PUBLIC_BRANDING_NAME
-# overrides runtimeConfig.public.branding.name). However the operator
-# interface is APP_NAME / APP_DESCRIPTION / APP_THEME_COLOR / APP_BACKGROUND_COLOR
-# / APP_SHORT_NAME — this script is the one-way bridge.
+#  2. (node pass) Map operator-facing APP_* env vars onto Nuxt's native
+#     NUXT_PUBLIC_BRANDING_* runtime-config override env vars BEFORE
+#     starting the node server.
 #
-# Without this mapping, operator-set APP_* values would be silently
-# ignored by the client; only the /api/webmanifest endpoint (which reads
-# process.env directly via readBranding) would see them, causing the SPA
-# shell and the manifest to disagree.
+# Operators who'd rather manage permissions themselves can pin the runtime
+# user in their compose file (`user: 1000:1000`). The container then starts
+# as uid 1000 from the start, the root pass below is skipped automatically,
+# and the script falls straight through to the env mapping.
+#
+# Background on the env mapping: nuxt.config.js declares
+# runtimeConfig.public.branding with hardcoded SkillGoblin defaults so that
+# Docker BUILD time (when 'npm run build' runs in Dockerfile.prod) doesn't
+# bake operator env into the bundle — at build time, compose 'environment:'
+# values do not exist. Nuxt 3 supports env-driven overrides of
+# runtimeConfig at server startup via env vars matching the config
+# structure (e.g. NUXT_PUBLIC_BRANDING_NAME overrides
+# runtimeConfig.public.branding.name). The operator interface, however, is
+# APP_NAME / APP_DESCRIPTION / APP_THEME_COLOR / APP_BACKGROUND_COLOR /
+# APP_SHORT_NAME — this script is the one-way bridge.
 
 set -e
+
+# ---------------------------------------------------------------------------
+# Pass 1: root -> repair perms -> drop to `node` and re-exec.
+# ---------------------------------------------------------------------------
+if [ "$(id -u)" = "0" ]; then
+  # SKILLGOBLIN_SKIP_PERM_REPAIR=1 disables the chown pass below while
+  # still dropping to the node user. Used by docker-compose.test.yml,
+  # where /app/data/branding and /app/data/content are bind-mounted from
+  # tracked repo fixtures and a recursive chown would dirty the working
+  # tree on the host.
+  if [ "${SKILLGOBLIN_SKIP_PERM_REPAIR:-}" != "1" ]; then
+    # Best-effort recursive chown for paths that need full write access.
+    # If the host has gone out of its way to make the volume non-chownable
+    # (read-only mount, exotic ACLs), we let the database open fail later
+    # with its own clearer error rather than aborting startup here -- the
+    # operator can still recover from inside the container.
+    for dir in /app/data/database /app/data/branding; do
+      if [ -d "$dir" ]; then
+        if ! chown -R node:node "$dir" 2>/dev/null; then
+          echo "[skillgoblin] warn: chown of $dir failed; continuing as-is" >&2
+        fi
+      fi
+    done
+    # data/content can be huge (typical course library = dozens of GB of
+    # video). Recursive chown on every restart would be pathological. Two
+    # targeted passes instead:
+    #   1. chown directory entries so the node user can CREATE new files
+    #      inside them (admin "Export course" and "Upload thumbnail" both
+    #      drop fresh files into per-course directories).
+    #   2. chown the specific filenames the app itself writes
+    #      (course.json and thumbnail.png) -- overwriting an existing
+    #      file with writeFileSync needs write perm on the FILE, not
+    #      just its parent. Operator-supplied cover.jpg / poster.jpg /
+    #      video files etc. stay under their original ownership; the
+    #      app only ever reads those.
+    if [ -d /app/data/content ]; then
+      if ! find /app/data/content -type d -exec chown node:node {} + 2>/dev/null; then
+        echo "[skillgoblin] warn: chown of content directory tree failed; continuing as-is" >&2
+      fi
+      if ! find /app/data/content -type f \( -name 'course.json' -o -name 'thumbnail.png' \) -exec chown node:node {} + 2>/dev/null; then
+        echo "[skillgoblin] warn: chown of app-managed files in content failed; continuing as-is" >&2
+      fi
+    fi
+  fi
+  # Drop privileges and re-enter this script as `node`. exec-replace so the
+  # node process is still PID 1 from Docker's perspective (signal handling,
+  # zombie reaping, healthcheck behavior all stay correct).
+  exec su-exec node:node "$0" "$@"
+fi
+
+# ---------------------------------------------------------------------------
+# Pass 2: running as `node` (uid 1000). Map env and launch.
+# ---------------------------------------------------------------------------
 
 # Map APP_* -> NUXT_PUBLIC_BRANDING_* only when NOT already set, so an
 # explicit NUXT_PUBLIC_BRANDING_* override (e.g. for testing) wins.
@@ -39,4 +103,12 @@ if [ -n "${APP_BACKGROUND_COLOR:-}" ] && [ -z "${NUXT_PUBLIC_BRANDING_BACKGROUND
   export NUXT_PUBLIC_BRANDING_BACKGROUND_COLOR="$APP_BACKGROUND_COLOR"
 fi
 
-exec node .output/server/index.mjs
+# exec "$@" runs whatever Docker passed as CMD (default: `node
+# .output/server/index.mjs`, set in Dockerfile.prod). Routing through
+# this entrypoint means a `docker run image bash` or compose
+# `command: <something>` override still benefits from the root-pass
+# drop above instead of running as root.
+if [ "$#" -eq 0 ]; then
+  exec node .output/server/index.mjs
+fi
+exec "$@"


### PR DESCRIPTION
## Summary

Smooth upgrade path for operators moving from a pre-uid-1000 image. Previously: bind-mounted \`data/\` owned by root → new container can't open SQLite → README told them to \`sudo chown -R 1000:1000 ./data\` on the host. Now: entrypoint detects the situation and fixes it on start.

## Mechanism

Standard root-init-then-drop pattern (postgres / redis / nextcloud do the same):

1. Dockerfile drops the \`USER node\` directive and adds \`su-exec\`. \`ENTRYPOINT\` always runs.
2. \`entrypoint.sh\` detects \`id -u == 0\` and runs bounded chown passes:
   - \`data/database\` recursive (small, full write needed)
   - \`data/branding\` recursive (small, full write needed)
   - \`data/content\` directory entries only (fast on big libraries — videos keep original ownership, still readable via mode 644)
   - \`data/content/**/{course.json,thumbnail.png}\` (so admin \`Export course\` and \`Upload thumbnail\` can overwrite existing root-owned files)
3. \`exec su-exec node:node "$0" "$@"\` drops privileges and re-runs the same script as \`node\`.
4. \`exec "$@"\` at the end runs whatever Docker passed as CMD — so \`docker run image bash\` and compose \`command:\` overrides also get the privilege drop.

Operators can opt out via:
- \`user: 1000:1000\` in compose → entrypoint detects non-root start, skips chown
- \`SKILLGOBLIN_SKIP_PERM_REPAIR=1\` env → drops privileges but skips chown

The test compose now sets the env var because its fixtures are tracked repo paths and recursive chown would dirty the working tree.

## Tradeoffs

The Node process — the only thing on the network — never runs as root. The brief root window is bounded to the entrypoint's chown pass and exec-replaced before any TCP listener exists. CodeQL DS-0002 / Trivy DKL-DI-0006 will flag the missing \`USER\` directive — trade-off is documented inline in the Dockerfile.

## Test plan

Three scenarios verified locally:

- [x] **Upgrade-from-root**: chown \`data/database\`, \`data/branding\`, \`data/content/*/course.json\` and \`thumbnail.png\` to root → restart container → entrypoint repairs them → SQLite opens, Node is PID 1 as uid 1000, healthy in ~7 s.
- [x] \`docker run image bash\` → uid 1000(node), not root.
- [x] \`docker run -e SKILLGOBLIN_SKIP_PERM_REPAIR=1 image id\` → uid 1000(node), no chown attempted.

## Codex review

4 rounds. Findings caught and fixed:
1. Content-write EACCES — chown \`data/content\` directory tree.
2. Overwrite-existing-file EACCES — file-level chown for \`course.json\` and \`thumbnail.png\`.
3. Test fixtures dirtied on host — \`SKILLGOBLIN_SKIP_PERM_REPAIR\` opt-out.
4. \`docker run image bash\` running as root after \`USER node\` removal — switched CMD → ENTRYPOINT + CMD.

Final round: clean.