### PR TITLE
fix(scanners): pin base image, suppress DS-0002, add docker dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,11 @@
 # Dependabot — automated dependency vulnerability scanning + update PRs.
 #
-# Watches two ecosystems:
+# Watches three ecosystems:
 #   1. npm  — the frontend Nuxt app (package.json lives in frontend/)
 #   2. github-actions — the workflow files in this directory
+#   3. docker — base-image FROMs in Dockerfile.prod (digest-pinned to
+#      satisfy OSSF Scorecard's PinnedDependencies rule; Dependabot
+#      bumps the digest when upstream republishes the tag)
 #
 # Schedule: weekly. Avoids PR storms while keeping deps fresh enough that
 # CVE-fix updates land within ~7 days. Bump to "daily" if you want
@@ -50,3 +53,19 @@ updates:
     labels:
       - dependencies
       - github-actions
+
+  # Dockerfile.prod sits at the repo root; both FROM lines point at the
+  # same digest-pinned node:20-alpine. Dependabot opens a single PR when
+  # upstream re-tags `node:20-alpine` to a new digest (typically a fresh
+  # alpine base or a node patch release).
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Bratislava
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - docker

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,8 @@ course.json
 # Test artifacts
 frontend/test-results
 frontend/playwright-report
+# Playwright MCP scratch (per-screenshot DOM snapshots / console logs)
+.playwright-mcp/
 frontend/tests/e2e/.tmp-data
 frontend/tests/fixtures/content/**/course.json
 

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,15 @@
+# Trivy misconfig findings that are deliberate trade-offs. One ID per line.
+# Trivy auto-loads this file from the working directory at scan time.
+
+# DS-0002 — "Image user should not be 'root'"
+# Dockerfile.prod intentionally omits the `USER node` directive so the
+# entrypoint script can run as root just long enough to chown the bind-
+# mounted /app/data on start (smooth-upgrade auto-perm-repair feature,
+# PR #88). Privileges are then dropped to the unprivileged `node` user
+# (uid 1000) via su-exec BEFORE any TCP listener is created — the Node
+# process that handles network traffic never runs as root.
+#
+# This pattern is shared by the official postgres / redis / nextcloud
+# images for the same reason. The trade-off is documented in
+# Dockerfile.prod, README.md, and the wiki.
+DS-0002

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS builder
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS builder
 
 WORKDIR /app
 
@@ -18,7 +18,7 @@ COPY frontend ./
 # Build the application
 RUN npm run build
 
-FROM node:20-alpine
+FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Two open code-scanning findings landed after [#88](https://github.com/VladoPortos/skillgoblin/pull/88):

| ID | Tool | Fix |
|---|---|---|
| **DS-0002** "Image user should not be 'root'" | Trivy | \`.trivyignore\` with justification (USER directive deliberately omitted so the entrypoint can chown bind-mounts before su-exec drop) |
| **PinnedDependenciesID** at line 21 | OSSF Scorecard | Pin both \`FROM node:20-alpine\` to \`@sha256:fb4cd12c...\` and add \`docker\` ecosystem to Dependabot for weekly digest bumps |

The DS-0002 trade-off is the price of the auto-perm-repair feature in #88 — reverting to \`USER node\` would re-break smooth upgrades from the older root-running image. The \`.trivyignore\` records the deliberate decision in a tool-readable form; the existing inline comments in Dockerfile.prod and the README/wiki keep the human-readable rationale.

The digest pin matches the pattern from [#80](https://github.com/VladoPortos/skillgoblin/pull/80) (GitHub Actions SHA-pinning). Dependabot will open a PR when upstream re-tags \`node:20-alpine\` to a fresh digest.

## Test plan

- [x] \`docker build\` resolves the digest and completes the build.
- [x] \`docker compose up -d\` against the manual stack — healthy.
- [x] Codex review — no findings.