### PR TITLE
chore(deps): pin Dockerfile to node:24-alpine LTS, ignore docker majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,9 +55,15 @@ updates:
       - github-actions
 
   # Dockerfile.prod sits at the repo root; both FROM lines point at the
-  # same digest-pinned node:20-alpine. Dependabot opens a single PR when
-  # upstream re-tags `node:20-alpine` to a new digest (typically a fresh
+  # same digest-pinned node:24-alpine. Dependabot opens a single PR when
+  # upstream re-tags `node:24-alpine` to a new digest (typically a fresh
   # alpine base or a node patch release).
+  #
+  # Major-version bumps for node are ignored here: we want to ride the
+  # active LTS line (24 → 26 in Oct 2026, etc.) and decide when to move
+  # by hand, not have Dependabot drag us onto an odd-numbered Current
+  # release the moment one ships. Drop the ignore block when you're
+  # ready to move to the next LTS.
   - package-ecosystem: docker
     directory: /
     schedule:
@@ -66,6 +72,9 @@ updates:
       time: "06:00"
       timezone: Europe/Bratislava
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]
     labels:
       - dependencies
       - docker

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS builder
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS builder
 
 WORKDIR /app
 
@@ -18,7 +18,7 @@ COPY frontend ./
 # Build the application
 RUN npm run build
 
-FROM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
 
 WORKDIR /app
 
@@ -33,7 +33,7 @@ WORKDIR /app
 RUN apk add --no-cache ffmpeg su-exec
 
 # Copy the build output from the builder stage. Chown to the unprivileged
-# `node` user (uid 1000) shipped by the official node:20-alpine image so the
+# `node` user (uid 1000) shipped by the official node:24-alpine image so the
 # runtime stage can drop privileges via USER below.
 COPY --from=builder --chown=node:node /app/.output ./.output
 


### PR DESCRIPTION
## Summary
- Pin both `FROM` lines in `Dockerfile.prod` to `node:24-alpine@sha256:d1b3b4da11ee...` (Node 24.15.0, active LTS) — was tracking `node:20-alpine` which goes EOL Apr 2026
- Add `ignore` rule for node major-version updates in `dependabot.yml` so Dependabot doesn't drag the base image off the LTS line again (this is what produced #91 → node 25 Current)
- Update inline comments to match
- **Supersedes #91** (node:25-alpine bump). Close #91 once this is merged.

## Why not Node 25 (which is what Dependabot proposed)
Node 25 is the odd-numbered "Current" release — never becomes LTS. Even-numbered lines (24, 26, 28…) are the ones that get LTS designation. Node 24 entered active LTS in Oct 2025 and is supported until Apr 2028.

## Test plan
- [x] `docker build -f Dockerfile.prod` succeeds with new pin (Node v24.15.0 confirmed inside image)
- [x] Native modules compile and load: `better-sqlite3`, `sharp`, `argon2`
- [x] Container starts; all 3 SQLite migrations apply (`001_initial`, `002_auth_hardening`, `003_allow_user_registration`)
- [x] `HEALTHCHECK` reaches `healthy` state
- [x] Smoke endpoints return 200: `/`, `/api/users`, `/api/courses`, `/api/status/scan`
- [x] Admin bootstrap works (`ADMIN_NAME`/`ADMIN_PASSWORD` env vars)
- [x] `actionlint` clean on all 5 workflow files (no related changes here, just confirmed unaffected)