### PR TITLE
fix(security): harden auth, rate limiting, uploads, and file serving

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,12 +37,37 @@ Out of scope (or addressed by deployment, not the app):
 
 ### Legacy credential-less accounts
 
-Upgraded installations can contain active accounts created by older releases
-without a password or PIN. Their first visitor may set a credential and claim
-the account because no prior secret exists to verify ownership. This recovery
-flow is retained for trusted-LAN deployments. If the wrong person claims an
-account, an administrator can reset its password or PIN from the Admin Panel.
-Do not rely on this flow on an untrusted network.
+Upgraded installations can contain active **non-admin** accounts created by
+older releases without a password or PIN. Their first visitor may set a
+credential and claim the account because no prior secret exists to verify
+ownership. This recovery flow is retained for trusted-LAN deployments and is
+hardened as follows:
+
+- **Admin accounts are never claimable this way.** A credential-less admin
+  (possible after upgrading from a pre-auth-hardening release) is refused by
+  the self-claim endpoint; only another administrator can set its credentials
+  from the Admin Panel. This closes the unauthenticated admin-takeover path.
+- **Claiming is atomic.** A compare-and-swap ensures only one racing request
+  can ever claim a given account; the loser gets a 409 and no session.
+
+If the wrong person claims a *non-admin* account, an administrator can reset
+its password or PIN from the Admin Panel. Do not rely on this flow on an
+untrusted network.
+
+## Deployment hardening
+
+The defaults suit a plain-HTTP trusted LAN. When exposing the service through
+a reverse proxy (or to a less-trusted network), set these so the app's
+defenses line up with your topology:
+
+| Env var | Default | When to set |
+|---------|---------|-------------|
+| `TRUST_PROXY_HOPS` | `0` (ignore `X-Forwarded-For`) | Set to the number of **trusted** reverse proxies in front of the app so login rate-limiting keys on the real client IP instead of a spoofable header. With `0`, a client-supplied `X-Forwarded-For` is ignored and the transport peer is used — safe, but every request behind a proxy shares one IP bucket. |
+| `COOKIE_SECURE` | auto-detect | Set to `true` when TLS is terminated by a proxy that does **not** forward `X-Forwarded-Proto=https` (otherwise the session cookie may be issued without the `Secure` flag). `false` forces it off for an intentional plain-HTTP LAN. |
+
+The app also caps request bodies (256 KiB for JSON APIs) to blunt memory-
+exhaustion attempts. As defense in depth, configure a body-size limit at your
+reverse proxy too (e.g. nginx `client_max_body_size`).
 
 ## Hall of fame
 

--- a/frontend/server/api/content/[...path].js
+++ b/frontend/server/api/content/[...path].js
@@ -3,7 +3,7 @@ import path from 'path';
 import { defineEventHandler, getRequestURL, createError, setResponseHeader, getRequestHeaders } from 'h3';
 import zlib from 'zlib';
 import { getDb } from '../../utils/db'; // Added for database access
-import { getContentDir, generateCourseId, resolveCourseById, resolveCourseDir, resolvePathInCourse, VIDEO_EXTENSIONS } from '../../utils/courseHelpers';
+import { getContentDir, generateCourseId, resolveCourseById, resolveCourseDir, resolvePathInCourse, assertResolvedInside, VIDEO_EXTENSIONS } from '../../utils/courseHelpers';
 import { loadThumbnail } from '../../utils/thumbnailUtils';
 import { parseSingleByteRange } from '../../utils/httpRange.js';
 import { requireAuth } from '../../utils/authz.js';
@@ -262,6 +262,8 @@ export default defineEventHandler(async (event) => {
     // have the player consume a real WebVTT track.
     if (!stats && path.extname(filePath).toLowerCase() === '.vtt') {
       const srtCandidate = filePath.slice(0, -4) + '.srt';
+      // Symlink-safe: reject an .srt that resolves outside the course root.
+      assertResolvedInside(courseDir, srtCandidate);
       try {
         const { convertSrtFileToVtt } = await import('../../utils/srtToVtt.js');
         const vttBuffer = await convertSrtFileToVtt(srtCandidate, fs);
@@ -287,8 +289,19 @@ export default defineEventHandler(async (event) => {
       });
     }
 
+    // Symlink-safe containment: the lexical resolvePathInCourse guard above
+    // can be defeated by a symlink component (e.g. a course containing
+    // `jump -> /etc`). Re-verify the real, symlink-resolved path is still
+    // inside the course directory before we open it. Throws 400 on escape.
+    assertResolvedInside(courseDir, filePath);
+
     // Determine content type based on file extension
     let contentType = 'application/octet-stream';
+    // Active/markup content must never render inline on our own origin: a
+    // malicious course bundle could otherwise run same-origin script against
+    // the authenticated (possibly admin) viewer and drive the admin APIs.
+    // We force a download (Content-Disposition: attachment) for those types.
+    let forceDownload = false;
     const ext = path.extname(filePath).toLowerCase();
 
     // We label all video extensions as video/mp4 because mainstream desktop
@@ -302,21 +315,38 @@ export default defineEventHandler(async (event) => {
       contentType = 'image/jpeg';
     } else if (ext === '.png') {
       contentType = 'image/png';
-    } else if (ext === '.js') {
-      contentType = 'application/javascript';
     } else if (ext === '.css') {
       contentType = 'text/css';
-    } else if (ext === '.html') {
-      contentType = 'text/html';
     } else if (ext === '.json') {
       contentType = 'application/json';
+    } else if (ext === '.vtt') {
+      // Subtitle track consumed by <track> — must stay inline text/vtt.
+      contentType = 'text/vtt; charset=utf-8';
     } else if (ext === '.svg') {
+      // Keep the image type so <img src="…​.svg"> subresources still render
+      // (nosniff requires a real image type), but force download on a
+      // top-level navigation so a script-bearing SVG can't execute here.
       contentType = 'image/svg+xml';
+      forceDownload = true;
+    } else if (ext === '.html' || ext === '.htm' || ext === '.xhtml' ||
+               ext === '.js' || ext === '.mjs' || ext === '.xml') {
+      contentType = 'application/octet-stream';
+      forceDownload = true;
+    } else {
+      // Unknown extension — download rather than let the browser guess.
+      forceDownload = true;
     }
-    
+
     // Set content type header
     setResponseHeader(event, 'Content-Type', contentType);
-    
+    if (forceDownload) {
+      setResponseHeader(
+        event,
+        'Content-Disposition',
+        `attachment; filename="${encodeURIComponent(path.basename(filePath))}"`
+      );
+    }
+
     // Common headers for all responses
     setResponseHeader(event, 'Connection', 'keep-alive');
     setResponseHeader(event, 'X-Content-Type-Options', 'nosniff');

--- a/frontend/server/api/courses/[id]/download-file.get.js
+++ b/frontend/server/api/courses/[id]/download-file.get.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { getDb } from '../../../utils/db';
-import { resolveCourseById, resolvePathInCourse } from '../../../utils/courseHelpers';
+import { resolveCourseById, resolvePathInCourse, assertResolvedInside } from '../../../utils/courseHelpers';
 import { requireAuth } from '../../../utils/authz';
 import { sendStream } from 'h3';
 
@@ -30,6 +30,10 @@ export default defineEventHandler(async (event) => {
   if (!fs.existsSync(absoluteFilePath)) {
     throw createError({ statusCode: 404, statusMessage: 'File not found.' });
   }
+
+  // Symlink-safe: reject a file that resolves outside the course root even
+  // though its lexical path is inside (a symlinked component).
+  assertResolvedInside(courseBasePath, absoluteFilePath);
 
   const stat = fs.statSync(absoluteFilePath);
   if (!stat.isFile()) {

--- a/frontend/server/api/courses/[id]/export-json.post.js
+++ b/frontend/server/api/courses/[id]/export-json.post.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { defineEventHandler, createError } from 'h3';
 import { getDb } from '../../../utils/db';
-import { resolveCourseById } from '../../../utils/courseHelpers';
+import { resolveCourseById, writeFileNoFollow } from '../../../utils/courseHelpers';
 import { buildCourseJsonPayload } from '../../../utils/courseJsonOverride.js';
 import { requireAdmin } from '../../../utils/authz';
 
@@ -24,7 +24,9 @@ export default defineEventHandler((event) => {
 
   const payload = buildCourseJsonPayload(row);
   const filePath = path.join(courseDir, 'course.json');
-  fs.writeFileSync(filePath, JSON.stringify(payload, null, 2) + '\n', 'utf8');
+  // No-follow write: if course.json is a planted symlink (e.g. -> the DB file)
+  // this replaces the link atomically instead of writing through it.
+  writeFileNoFollow(filePath, JSON.stringify(payload, null, 2) + '\n');
 
   return { success: true, path: 'course.json', fields: payload };
 });

--- a/frontend/server/api/courses/edit.post.js
+++ b/frontend/server/api/courses/edit.post.js
@@ -3,6 +3,7 @@ import busboy from 'busboy';
 import fs from 'fs';
 import path from 'path';
 import { getCourseRootPath, processThumbnailBuffer } from '../../utils/thumbnailUtils';
+import { writeFileNoFollow } from '../../utils/courseHelpers';
 import { requireAdmin } from '../../utils/authz';
 
 export default defineEventHandler(async (event) => {
@@ -167,7 +168,7 @@ export default defineEventHandler(async (event) => {
         const localThumbnailPath = path.join(courseRoot, thumbnailFilename);
         try {
           fs.mkdirSync(courseRoot, { recursive: true });
-          fs.writeFileSync(localThumbnailPath, thumbnailBuffer);
+          writeFileNoFollow(localThumbnailPath, thumbnailBuffer);
         } catch (error) {
           console.error('Error saving thumbnail to filesystem:', error);
         }

--- a/frontend/server/api/courses/export-json-all.post.js
+++ b/frontend/server/api/courses/export-json-all.post.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { defineEventHandler } from 'h3';
 import { getDb } from '../../utils/db';
-import { resolveCourseDir } from '../../utils/courseHelpers';
+import { resolveCourseDir, writeFileNoFollow } from '../../utils/courseHelpers';
 import { buildCourseJsonPayload } from '../../utils/courseJsonOverride.js';
 import { requireAdmin } from '../../utils/authz';
 
@@ -36,7 +36,7 @@ export default defineEventHandler((event) => {
     const payload = buildCourseJsonPayload(row);
 
     try {
-      fs.writeFileSync(path.join(dir, 'course.json'), JSON.stringify(payload, null, 2) + '\n', 'utf8');
+      writeFileNoFollow(path.join(dir, 'course.json'), JSON.stringify(payload, null, 2) + '\n');
       written.push(row.id);
     } catch (err) {
       console.error(`[export-json-all] write failed for ${row.id}:`, err);

--- a/frontend/server/api/users/[id].js
+++ b/frontend/server/api/users/[id].js
@@ -26,6 +26,13 @@ export default defineEventHandler(async (event) => {
     if (!user) {
       return createError({ statusCode: 404, statusMessage: 'User not found' });
     }
+    // Anonymous callers (the pre-login credential-routing fetch) get name,
+    // avatar and credential-presence flags but NOT isAdmin — don't reveal which
+    // account is the administrator to an unauthenticated visitor.
+    if (!event.context.user) {
+      const { isAdmin, ...safe } = user;
+      return safe;
+    }
     return user;
   } catch (error) {
     console.error('Error fetching user:', error);

--- a/frontend/server/api/users/[id].js
+++ b/frontend/server/api/users/[id].js
@@ -26,13 +26,9 @@ export default defineEventHandler(async (event) => {
     if (!user) {
       return createError({ statusCode: 404, statusMessage: 'User not found' });
     }
-    // Anonymous callers (the pre-login credential-routing fetch) get name,
-    // avatar and credential-presence flags but NOT isAdmin — don't reveal which
-    // account is the administrator to an unauthenticated visitor.
-    if (!event.context.user) {
-      const { isAdmin, ...safe } = user;
-      return safe;
-    }
+    // Per-user fetch used by the login screen to route password vs PIN input,
+    // so it must return has_password / has_pin. This is a single-record lookup
+    // (not the bulk roster), so it isn't the enumeration surface the list is.
     return user;
   } catch (error) {
     console.error('Error fetching user:', error);

--- a/frontend/server/api/users/auth.js
+++ b/frontend/server/api/users/auth.js
@@ -1,9 +1,10 @@
-import { defineEventHandler, readBody, createError, setCookie, getRequestIP } from 'h3';
+import { defineEventHandler, readBody, createError, setCookie } from 'h3';
 import { getDb } from '../../utils/db';
 import { verifyCredential, hashCredential } from '../../utils/credentials';
 import { createSession } from '../../utils/sessions';
 import { sessionCookieOpts, SESSION_COOKIE } from '../../middleware/session';
-import { checkRateLimit, recordFailure, recordSuccess } from '../../utils/rate-limit';
+import { checkRateLimit, recordFailure, recordSuccess, ACCOUNT_FAIL_THRESHOLD } from '../../utils/rate-limit';
+import { getClientIp } from '../../utils/requestIp';
 import { getBoolSetting } from '../../utils/systemSettings';
 
 // A hash to verify-against when the user/credential lookup misses, so the
@@ -38,18 +39,35 @@ export default defineEventHandler(async (event) => {
       return createError({ statusCode: 400, statusMessage: 'User ID is required' });
     }
 
-    // Rate limit per (userId, ip). The bucket is shared across password
-    // and PIN attempts — five wrong attempts in any combination locks the
-    // pair out for a while.
-    const ip = getRequestIP(event, { xForwardedFor: true }) || 'unknown';
-    const rlKey = `auth:${userId}:${ip}`;
-    const rl = checkRateLimit(rlKey);
-    if (!rl.allowed) {
+    // Rate limit on two buckets:
+    //   - per (userId, ip): five wrong attempts (password/PIN combined) lock
+    //     the pair out, exponential backoff.
+    //   - per userId (account-wide): survives IP rotation, so an attacker who
+    //     spoofs a fresh X-Forwarded-For each request (or comes from a botnet)
+    //     still trips a lockout after ACCOUNT_FAIL_THRESHOLD total failures.
+    // The IP itself comes from getClientIp(), which does NOT trust
+    // client-supplied X-Forwarded-For unless the operator opts in via
+    // TRUST_PROXY_HOPS — closing the header-spoof bypass.
+    const ip = getClientIp(event);
+    const ipKey = `auth:${userId}:${ip}`;
+    const acctKey = `auth-acct:${userId}`;
+    const rlIp = checkRateLimit(ipKey);
+    const rlAcct = checkRateLimit(acctKey);
+    if (!rlIp.allowed || !rlAcct.allowed) {
+      const retryAfterSeconds = Math.max(rlIp.retryAfterSeconds || 0, rlAcct.retryAfterSeconds || 0);
       return createError({
         statusCode: 429,
-        statusMessage: `Too many failed attempts. Try again in ${rl.retryAfterSeconds}s.`
+        statusMessage: `Too many failed attempts. Try again in ${retryAfterSeconds}s.`
       });
     }
+    const recordAuthFailure = () => {
+      recordFailure(ipKey);
+      recordFailure(acctKey, { threshold: ACCOUNT_FAIL_THRESHOLD });
+    };
+    const recordAuthSuccess = () => {
+      recordSuccess(ipKey);
+      recordSuccess(acctKey);
+    };
 
     const db = getDb();
     const user = db
@@ -64,7 +82,7 @@ export default defineEventHandler(async (event) => {
       // Mirror the response shape AND timing of the "wrong password" path so
       // we don't leak user existence via response shape OR response time.
       await verifyCredential(password || pin || 'x', await getDummyHash());
-      recordFailure(rlKey);
+      recordAuthFailure();
       return { success: false, message: 'Invalid credentials' };
     }
 
@@ -79,7 +97,7 @@ export default defineEventHandler(async (event) => {
     }
 
     if (!password && !pin) {
-      recordFailure(rlKey);
+      recordAuthFailure();
       return { success: false, message: 'Invalid credentials' };
     }
 
@@ -113,19 +131,34 @@ export default defineEventHandler(async (event) => {
     }
 
     if (!matched) {
-      recordFailure(rlKey);
+      recordAuthFailure();
       return { success: false, message: 'Invalid credentials' };
     }
 
     // Best-effort inline migration: if the value matched but is still
-    // plaintext, rewrite it as an argon2 hash. Failure here must NOT
-    // block login — it just means the next login will retry.
+    // plaintext, rewrite it as an argon2 hash. Failure to *hash* must NOT
+    // block login — the next login will retry. But the write is a
+    // compare-and-swap against the exact legacy value we verified: if an
+    // admin reset the credential while we were hashing, the swap affects zero
+    // rows, meaning the credential we authenticated with is no longer current.
+    // In that case we refuse to issue a session rather than clobber the reset
+    // and hand out access after the admin's session revocation.
     if (needsRehash) {
+      const column = matched === 'password' ? 'password' : 'pin';
+      const verifiedValue = matched === 'password' ? user.password : user.pin;
       try {
         const fresh = await hashCredential(matched === 'password' ? password : pin);
-        const column = matched === 'password' ? 'password' : 'pin';
-        db.prepare(`UPDATE users SET ${column} = ? WHERE id = ?`).run(fresh, userId);
+        const res = db
+          .prepare(`UPDATE users SET ${column} = ? WHERE id = ? AND ${column} = ?`)
+          .run(fresh, userId, verifiedValue);
+        if (res.changes !== 1) {
+          console.warn(`[auth] credential changed mid-login for ${userId}; refusing session`);
+          recordAuthFailure();
+          return { success: false, message: 'Invalid credentials' };
+        }
       } catch (err) {
+        // Hashing/storage itself failed — nothing was overwritten, so the
+        // reset race does not apply; let the login proceed and retry later.
         console.warn(`[auth] inline rehash failed for ${userId}:`, err.message);
       }
     }
@@ -134,7 +167,7 @@ export default defineEventHandler(async (event) => {
     const userAgent = event.node.req.headers['user-agent'] || null;
     const { token, expiresAt } = createSession(db, userId, { userAgent });
     setCookie(event, SESSION_COOKIE, token, sessionCookieOpts(event, expiresAt));
-    recordSuccess(rlKey);
+    recordAuthSuccess();
 
     // Surface "you should add a password" prompts to the client. We do NOT
     // refuse the login — the user gets in but the UI walks them through

--- a/frontend/server/api/users/bootstrap-credentials.post.js
+++ b/frontend/server/api/users/bootstrap-credentials.post.js
@@ -1,9 +1,10 @@
-import { defineEventHandler, readBody, createError, setCookie, getRequestIP } from 'h3';
+import { defineEventHandler, readBody, createError, setCookie } from 'h3';
 import { getDb } from '../../utils/db';
 import { hashCredential } from '../../utils/credentials';
 import { createSession } from '../../utils/sessions';
 import { sessionCookieOpts, SESSION_COOKIE } from '../../middleware/session';
-import { checkRateLimit, recordFailure, recordSuccess } from '../../utils/rate-limit';
+import { checkRateLimit, recordFailure, recordSuccess, ACCOUNT_FAIL_THRESHOLD } from '../../utils/rate-limit';
+import { getClientIp } from '../../utils/requestIp';
 import { getBoolSetting } from '../../utils/systemSettings';
 
 // POST /api/users/bootstrap-credentials  Body: { userId, password?, pin? }
@@ -38,35 +39,57 @@ export default defineEventHandler(async (event) => {
     });
   }
 
-  // Rate limit per (userId, ip) like /api/users/auth — this endpoint is
-  // unauthenticated and lets a caller claim a credential-less account.
-  const ip = getRequestIP(event, { xForwardedFor: true }) || 'unknown';
-  const rlKey = `bootstrap:${userId}:${ip}`;
-  const rl = checkRateLimit(rlKey);
-  if (!rl.allowed) {
+  // Rate limit like /api/users/auth — this endpoint is unauthenticated and
+  // lets a caller claim a credential-less account. Two buckets (per-ip and
+  // account-wide) so header-spoofed source addresses can't reset the counter;
+  // getClientIp() does not trust X-Forwarded-For unless TRUST_PROXY_HOPS is set.
+  const ip = getClientIp(event);
+  const ipKey = `bootstrap:${userId}:${ip}`;
+  const acctKey = `bootstrap-acct:${userId}`;
+  const rlIp = checkRateLimit(ipKey);
+  const rlAcct = checkRateLimit(acctKey);
+  if (!rlIp.allowed || !rlAcct.allowed) {
+    const retryAfterSeconds = Math.max(rlIp.retryAfterSeconds || 0, rlAcct.retryAfterSeconds || 0);
     return createError({
       statusCode: 429,
-      statusMessage: `Too many attempts. Try again in ${rl.retryAfterSeconds}s.`
+      statusMessage: `Too many attempts. Try again in ${retryAfterSeconds}s.`
     });
   }
+  const recordClaimFailure = () => {
+    recordFailure(ipKey);
+    recordFailure(acctKey, { threshold: ACCOUNT_FAIL_THRESHOLD });
+  };
 
   const db = getDb();
   const user = db
-    .prepare('SELECT id, password, pin, is_active FROM users WHERE id = ?')
+    .prepare('SELECT id, password, pin, is_active, isAdmin FROM users WHERE id = ?')
     .get(userId);
   if (!user) {
-    recordFailure(rlKey);
+    recordClaimFailure();
     return createError({ statusCode: 404, statusMessage: 'User not found' });
   }
+  // SECURITY: never let this unauthenticated self-claim path grant an admin
+  // account. A legacy admin can survive the auth-hardening upgrade with no
+  // password and no PIN (is_active defaults to 1); without this guard an
+  // anonymous caller who reads the admin's id from the public user list could
+  // set a password and seize administrator access. Admin credentials must be
+  // (re)set by another admin via the user-management panel.
+  if (user.isAdmin) {
+    recordClaimFailure();
+    return createError({
+      statusCode: 403,
+      statusMessage: 'This account cannot set credentials here; ask an administrator to reset it.'
+    });
+  }
   if (user.password || user.pin) {
-    recordFailure(rlKey);
+    recordClaimFailure();
     return createError({
       statusCode: 409,
       statusMessage: 'This account already has credentials. Use the normal sign-in screen.'
     });
   }
   if (!user.is_active) {
-    recordFailure(rlKey);
+    recordClaimFailure();
     return createError({
       statusCode: 403,
       statusMessage: 'This account is awaiting administrator approval'
@@ -85,13 +108,31 @@ export default defineEventHandler(async (event) => {
   const hashedPassword = password ? await hashCredential(password) : null;
   const hashedPin = pin && allowPin ? await hashCredential(pin) : null;
 
-  db.prepare(`UPDATE users SET password = ?, pin = ? WHERE id = ?`)
+  // Atomic claim: only write if the row is STILL credential-less. Two racing
+  // requests both pass the checks above and await argon2; the compare-and-swap
+  // guarantees exactly one wins. The loser gets 409 and no session, so a
+  // credential-less account can never be claimed twice.
+  const claim = db
+    .prepare(`
+      UPDATE users SET password = ?, pin = ?
+      WHERE id = ?
+        AND (password IS NULL OR password = '')
+        AND (pin IS NULL OR pin = '')
+    `)
     .run(hashedPassword, hashedPin, userId);
+  if (claim.changes !== 1) {
+    recordClaimFailure();
+    return createError({
+      statusCode: 409,
+      statusMessage: 'This account already has credentials. Use the normal sign-in screen.'
+    });
+  }
 
   const userAgent = event.node.req.headers['user-agent'] || null;
   const { token, expiresAt } = createSession(db, userId, { userAgent });
   setCookie(event, SESSION_COOKIE, token, sessionCookieOpts(event, expiresAt));
-  recordSuccess(rlKey);
+  recordSuccess(ipKey);
+  recordSuccess(acctKey);
 
   const refreshed = db
     .prepare('SELECT id, name, avatar, isAdmin, is_active FROM users WHERE id = ?')

--- a/frontend/server/api/users/bootstrap-credentials.post.js
+++ b/frontend/server/api/users/bootstrap-credentials.post.js
@@ -68,24 +68,28 @@ export default defineEventHandler(async (event) => {
     recordClaimFailure();
     return createError({ statusCode: 404, statusMessage: 'User not found' });
   }
-  // SECURITY: never let this unauthenticated self-claim path grant an admin
-  // account. A legacy admin can survive the auth-hardening upgrade with no
-  // password and no PIN (is_active defaults to 1); without this guard an
-  // anonymous caller who reads the admin's id from the public user list could
-  // set a password and seize administrator access. Admin credentials must be
-  // (re)set by another admin via the user-management panel.
-  if (user.isAdmin) {
-    recordClaimFailure();
-    return createError({
-      statusCode: 403,
-      statusMessage: 'This account cannot set credentials here; ask an administrator to reset it.'
-    });
-  }
+  // An account that already has any credential is handled by the normal
+  // sign-in screen — check this first so an admin who already has a password
+  // gets the informative 409 rather than the admin-block 403 below.
   if (user.password || user.pin) {
     recordClaimFailure();
     return createError({
       statusCode: 409,
       statusMessage: 'This account already has credentials. Use the normal sign-in screen.'
+    });
+  }
+  // SECURITY: never let this unauthenticated self-claim path grant an admin
+  // account. A legacy admin can survive the auth-hardening upgrade with no
+  // password and no PIN (is_active defaults to 1); without this guard an
+  // anonymous caller who reads the admin's id from the public user list could
+  // set a password and seize administrator access. Admin credentials must be
+  // (re)set by another admin via the user-management panel. (Reached only for
+  // a credential-less admin — the has-credentials case returned 409 above.)
+  if (user.isAdmin) {
+    recordClaimFailure();
+    return createError({
+      statusCode: 403,
+      statusMessage: 'This account cannot set credentials here; ask an administrator to reset it.'
     });
   }
   if (!user.is_active) {

--- a/frontend/server/api/users/index.js
+++ b/frontend/server/api/users/index.js
@@ -34,12 +34,14 @@ export default defineEventHandler(async (event) => {
         FROM users
         ORDER BY created_at DESC
       `).all();
-      // The login picker (unauthenticated) only needs id/name/avatar; it fetches
-      // credential state per-user on selection. Do NOT hand anonymous callers
-      // the isAdmin flag — it tells an attacker exactly which account to target
-      // for takeover. Authenticated callers (admin panel) still get it.
+      // The login picker (unauthenticated) needs isAdmin (to detect first-run /
+      // draw the admin badge) and id/name/avatar. It does NOT read the
+      // credential-presence flags from this list — those are fetched per-user on
+      // selection. So don't bulk-expose has_password / has_pin to anonymous
+      // callers: that map of "which accounts have weak/no credentials" is pure
+      // reconnaissance. Authenticated callers (admin panel) still get everything.
       const authed = !!event.context.user;
-      return authed ? rows : rows.map(({ isAdmin, ...rest }) => rest);
+      return authed ? rows : rows.map(({ has_password, has_pin, ...rest }) => rest);
     } catch (error) {
       console.error('Error fetching users:', error);
       return createError({ statusCode: 500, statusMessage: 'Failed to fetch users' });

--- a/frontend/server/api/users/index.js
+++ b/frontend/server/api/users/index.js
@@ -27,14 +27,19 @@ export default defineEventHandler(async (event) => {
   if (method === 'GET') {
     try {
       const db = getDb();
-      const users = db.prepare(`
+      const rows = db.prepare(`
         SELECT id, name, avatar, isAdmin, is_active, created_at,
                CASE WHEN password IS NOT NULL AND password != '' THEN 1 ELSE 0 END AS has_password,
                CASE WHEN pin      IS NOT NULL AND pin      != '' THEN 1 ELSE 0 END AS has_pin
         FROM users
         ORDER BY created_at DESC
       `).all();
-      return users || [];
+      // The login picker (unauthenticated) only needs id/name/avatar; it fetches
+      // credential state per-user on selection. Do NOT hand anonymous callers
+      // the isAdmin flag — it tells an attacker exactly which account to target
+      // for takeover. Authenticated callers (admin panel) still get it.
+      const authed = !!event.context.user;
+      return authed ? rows : rows.map(({ isAdmin, ...rest }) => rest);
     } catch (error) {
       console.error('Error fetching users:', error);
       return createError({ statusCode: 500, statusMessage: 'Failed to fetch users' });
@@ -111,28 +116,42 @@ export default defineEventHandler(async (event) => {
         });
       }
 
-      // Admin-create is an explicit, knowing action — it bypasses the
-      // global auto-approve setting and lands the user as is_active=1.
-      // Anonymous self-signup honors the setting as before.
-      let isActive;
-      if (isAdminCaller) {
-        isActive = 1;
-      } else {
-        isActive = getBoolSetting(db, 'auto_approve_new_users', false) ? 1 : 0;
-      }
-
       const userId = uuidv4();
       const hashedPassword = password ? await hashCredential(password) : null;
       const hashedPin = effectivePin ? await hashCredential(effectivePin) : null;
 
-      const result = db.prepare(`
-        INSERT INTO users (id, name, avatar, password, pin, theme, isAdmin, is_active)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-      `).run(userId, name, avatar, hashedPassword, hashedPin, 'dark', 0, isActive);
-
-      if (result.changes !== 1) {
-        return createError({ statusCode: 500, statusMessage: 'Failed to create user' });
-      }
+      // Commit the policy re-check and the insert atomically. The gate and the
+      // auto-approve value were sampled earlier, but body parsing and argon2
+      // hashing are async — an admin could have flipped
+      // allow_user_registration / auto_approve_new_users in that window. We
+      // re-read both inside a synchronous transaction with no await before the
+      // INSERT, so a now-disallowed signup can't slip through and two
+      // concurrent signups can't both pass the name check.
+      //
+      // Admin-create is an explicit, knowing action — it bypasses the global
+      // auto-approve setting and lands the user as is_active=1. Anonymous
+      // self-signup honors the settings as they stand at insert time.
+      const createInTxn = db.transaction(() => {
+        const allowNow = getBoolSetting(db, 'allow_user_registration', true);
+        if (!allowNow && !isAdminCaller) {
+          throw createError({ statusCode: 403, statusMessage: 'Registration is disabled on this instance' });
+        }
+        const dup = db.prepare('SELECT id FROM users WHERE name = ? COLLATE NOCASE').get(name);
+        if (dup) {
+          throw createError({ statusCode: 409, statusMessage: 'A user with this name already exists' });
+        }
+        const isActive = isAdminCaller
+          ? 1
+          : (getBoolSetting(db, 'auto_approve_new_users', false) ? 1 : 0);
+        const result = db.prepare(`
+          INSERT INTO users (id, name, avatar, password, pin, theme, isAdmin, is_active)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        `).run(userId, name, avatar, hashedPassword, hashedPin, 'dark', 0, isActive);
+        if (result.changes !== 1) {
+          throw createError({ statusCode: 500, statusMessage: 'Failed to create user' });
+        }
+      });
+      createInTxn();
 
       const newUser = db.prepare(`
         SELECT id, name, avatar, isAdmin, is_active,
@@ -142,6 +161,10 @@ export default defineEventHandler(async (event) => {
       `).get(userId);
       return newUser;
     } catch (error) {
+      // Typed errors thrown from the create transaction (403 disabled, 409
+      // duplicate, ...) carry their intended status — surface it rather than
+      // masking it as a generic 500.
+      if (error?.statusCode) return error;
       if (isUserNameConstraintError(error)) {
         return createError({ statusCode: 409, statusMessage: 'A user with this name already exists' });
       }

--- a/frontend/server/middleware/bodyLimit.js
+++ b/frontend/server/middleware/bodyLimit.js
@@ -1,0 +1,70 @@
+import { defineEventHandler, createError } from 'h3';
+
+// Global request-body size guard.
+//
+// SECURITY: h3's readBody()/readRawBody() buffer every chunk into memory with
+// no byte cap. An unauthenticated caller (auth, bootstrap-credentials, signup
+// all read the body before doing anything else) could stream a multi-gigabyte
+// body — via a large Content-Length or a lying/omitted length with
+// Transfer-Encoding: chunked — and exhaust the process.
+//
+// We cap it here, before any handler runs. For non-multipart requests we read
+// the raw stream ourselves with a hard byte ceiling and cache the result on
+// req.rawBody, which h3's readRawBody() reuses (see its _rawBody lookup) so the
+// downstream handler's readBody() does not re-read a now-consumed stream.
+//
+// Multipart uploads are intentionally skipped: the upload handler
+// (courses/edit.post.js) pipes the raw stream into busboy itself and enforces
+// its own per-file limit, so buffering here would starve it.
+const MAX_BODY_BYTES = 256 * 1024; // 256 KiB — JSON APIs here are tiny
+const BODY_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+export default defineEventHandler(async (event) => {
+  const req = event.node.req;
+  const method = (req.method || 'GET').toUpperCase();
+  if (!BODY_METHODS.has(method)) return;
+
+  const contentType = req.headers['content-type'] || '';
+  if (contentType.startsWith('multipart/form-data')) return;
+
+  // Reject an oversized declared length before reading a single byte.
+  const declared = Number.parseInt(req.headers['content-length'] || '', 10);
+  if (Number.isFinite(declared) && declared > MAX_BODY_BYTES) {
+    throw createError({ statusCode: 413, statusMessage: 'Request body too large' });
+  }
+
+  // Nothing to read (no length, not chunked) — mirror h3's own guard.
+  const isChunked = /\bchunked\b/i.test(String(req.headers['transfer-encoding'] || ''));
+  if (!declared && !isChunked) return;
+
+  // Already buffered by something upstream — don't double-read.
+  if (req.rawBody || req.body) return;
+
+  const body = await new Promise((resolve, reject) => {
+    const chunks = [];
+    let total = 0;
+    const cleanup = () => {
+      req.off('data', onData);
+      req.off('end', onEnd);
+      req.off('error', onError);
+    };
+    const onData = (chunk) => {
+      total += chunk.length;
+      if (total > MAX_BODY_BYTES) {
+        cleanup();
+        req.destroy();
+        reject(createError({ statusCode: 413, statusMessage: 'Request body too large' }));
+        return;
+      }
+      chunks.push(chunk);
+    };
+    const onEnd = () => { cleanup(); resolve(Buffer.concat(chunks)); };
+    const onError = (err) => { cleanup(); reject(err); };
+    req.on('data', onData);
+    req.on('end', onEnd);
+    req.on('error', onError);
+  });
+
+  // Cache for h3's readRawBody() (checks event.node.req.rawBody).
+  req.rawBody = body;
+});

--- a/frontend/server/middleware/session.js
+++ b/frontend/server/middleware/session.js
@@ -25,22 +25,30 @@ import {
 // refresh on the same response would mix Set-Cookie with a publicly-cacheable
 // payload — unsafe behind any shared cache/CDN that could serve another
 // user's cookie. Skipping the middleware keeps those responses cookie-free.
-const SKIP_PATH_PREFIXES = [
+// Public API endpoints — matched EXACTLY (a trailing query string is allowed).
+// Using exact match, not startsWith, so a future route such as
+// /api/logo-uploader can never silently inherit this auth-skip.
+const SKIP_EXACT = new Set([
   '/api/random-banner',
   '/api/logo',
   '/api/login-banner',
-  '/api/webmanifest',
+  '/api/webmanifest'
+]);
+
+// Static asset directories — genuine prefixes (they name a path segment).
+const SKIP_PREFIXES = [
   '/_nuxt/',
-  '/favicon',
   '/banners/',
   '/images/',
-  '/logos/'
+  '/logos/',
+  '/favicon'
 ];
 
 export default defineEventHandler(async (event) => {
-  const url = event.node.req.url || '';
-  for (const prefix of SKIP_PATH_PREFIXES) {
-    if (url.startsWith(prefix)) return;
+  const pathname = (event.node.req.url || '').split('?')[0];
+  if (SKIP_EXACT.has(pathname)) return;
+  for (const prefix of SKIP_PREFIXES) {
+    if (pathname.startsWith(prefix)) return;
   }
 
   const token = getCookie(event, SESSION_COOKIE);

--- a/frontend/server/middleware/session.js
+++ b/frontend/server/middleware/session.js
@@ -79,6 +79,16 @@ export function sessionCookieOpts(event, expiresAtMs) {
 }
 
 function isSecureRequest(event) {
+  // Explicit operator override. A reverse proxy that terminates TLS but does
+  // NOT forward X-Forwarded-Proto would otherwise leave the 30-day session
+  // cookie without the Secure attribute (eligible to leak over plaintext).
+  // COOKIE_SECURE=true forces Secure on; COOKIE_SECURE=false is the escape
+  // hatch for an intentional plain-HTTP LAN deployment. Unset/auto keeps the
+  // request-scheme detection below so HTTP-LAN logins are not broken by default.
+  const override = (process.env.COOKIE_SECURE || '').trim().toLowerCase();
+  if (override === 'true') return true;
+  if (override === 'false') return false;
+
   // Direct TLS termination → req.encrypted is true on the underlying socket.
   if (event.node.req.socket?.encrypted) return true;
   // Behind a reverse proxy: trust the standard forwarded header.

--- a/frontend/server/utils/courseHelpers.js
+++ b/frontend/server/utils/courseHelpers.js
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import path from 'path';
 import { createError } from 'h3';
 
@@ -55,6 +56,54 @@ export function resolvePathInCourse(courseDir, ...segments) {
     throw createError({ statusCode: 400, statusMessage: 'Invalid path' });
   }
   return candidate;
+}
+
+// Lexical containment (resolvePathInCourse) proves only that the *pathname*
+// sits under the course root; a symlink component can still point outside.
+// This re-checks an already-resolved path AFTER symlink resolution, right
+// before a read, so a course containing e.g. `jump -> /etc` can't exfiltrate
+// files outside the content tree.
+//
+// Returns the real path on success, null if the path doesn't exist (callers do
+// their own existence check), and throws 400 on an out-of-root escape.
+export function assertResolvedInside(root, candidatePath) {
+  let realRoot;
+  try {
+    realRoot = fs.realpathSync(path.resolve(root));
+  } catch {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid path' });
+  }
+  let realCandidate;
+  try {
+    realCandidate = fs.realpathSync(candidatePath);
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return null;
+    throw createError({ statusCode: 400, statusMessage: 'Invalid path' });
+  }
+  const rootWithSep = realRoot.endsWith(path.sep) ? realRoot : realRoot + path.sep;
+  if (realCandidate !== realRoot && !realCandidate.startsWith(rootWithSep)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid path' });
+  }
+  return realCandidate;
+}
+
+// Write a file without following a symlink at the destination. If an attacker
+// (or a malicious course bundle) planted `course.json -> /app/data/database/
+// database.sqlite`, a plain writeFileSync would follow the link and truncate
+// the DB. We write a fresh temp file with O_EXCL ('wx', so we never write
+// THROUGH a planted link) and atomically rename it over the target — rename
+// replaces the directory entry itself, swapping out any symlink rather than
+// following it.
+export function writeFileNoFollow(targetPath, data) {
+  const dir = path.dirname(targetPath);
+  const tmp = path.join(dir, `.${path.basename(targetPath)}.tmp-${process.pid}-${Date.now()}`);
+  fs.writeFileSync(tmp, data, { flag: 'wx' });
+  try {
+    fs.renameSync(tmp, targetPath);
+  } catch (err) {
+    try { fs.unlinkSync(tmp); } catch { /* best effort */ }
+    throw err;
+  }
 }
 
 // Function to generate a course ID from a title

--- a/frontend/server/utils/courseJsonOverride.js
+++ b/frontend/server/utils/courseJsonOverride.js
@@ -20,13 +20,30 @@ export function hasCourseJson(courseFolderPath) {
   }
 }
 
+// course.json holds four short string fields; a sane file is well under a
+// kilobyte. Cap the read so a hostile/accidental multi-gigabyte course.json
+// can't be slurped into memory and wedge the scan.
+const MAX_COURSE_JSON_BYTES = 1 * 1024 * 1024; // 1 MiB
+
 // Read and parse course.json from a course folder. Strips a leading BOM and
 // validates that the top level is a plain object. Returns null on any
-// failure (missing file, bad JSON, wrong shape) after logging a warning so
-// an operator can debug without crashing the scan.
+// failure (missing file, bad JSON, wrong shape, oversized) after logging a
+// warning so an operator can debug without crashing the scan.
 export function readCourseJson(courseFolderPath) {
   const filePath = path.join(courseFolderPath, 'course.json');
   let raw;
+  try {
+    const st = fs.statSync(filePath);
+    if (st.size > MAX_COURSE_JSON_BYTES) {
+      console.warn(`[courseJsonOverride] ${filePath} is ${st.size} bytes; exceeds ${MAX_COURSE_JSON_BYTES}-byte cap, ignoring.`);
+      return null;
+    }
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      console.warn(`[courseJsonOverride] cannot stat ${filePath}: ${err.message}`);
+    }
+    return null;
+  }
   try {
     raw = fs.readFileSync(filePath, 'utf8');
   } catch (err) {

--- a/frontend/server/utils/rate-limit.js
+++ b/frontend/server/utils/rate-limit.js
@@ -11,10 +11,17 @@
 // Single-process by design. The app runs as one Nitro process per
 // container; there's no cluster mode to worry about.
 
-const FAIL_THRESHOLD = 5;          // first lockout after this many fails in a row
+export const FAIL_THRESHOLD = 5;          // first lockout after this many fails in a row
 const BASE_LOCKOUT_MS = 30 * 1000; // 30 seconds
 const MAX_LOCKOUT_MS = 30 * 60 * 1000; // cap at 30 minutes
 const STALE_AFTER_MS = 24 * 60 * 60 * 1000; // GC entries that haven't been touched in 24h
+
+// Account-wide threshold (see auth handler). Deliberately higher than the
+// per-(user,ip) threshold: it aggregates every IP hitting one account, so it
+// must tolerate a few devices fat-fingering a PIN before it engages, while
+// still bounding a distributed / IP-rotating brute-force that slips past the
+// per-IP bucket.
+export const ACCOUNT_FAIL_THRESHOLD = 20;
 
 const buckets = new Map();
 let lastGcAt = 0;
@@ -28,9 +35,9 @@ function gcIfDue(now) {
   }
 }
 
-function lockoutDuration(failCount) {
-  if (failCount < FAIL_THRESHOLD) return 0;
-  const exp = failCount - FAIL_THRESHOLD;
+function lockoutDuration(failCount, threshold) {
+  if (failCount < threshold) return 0;
+  const exp = failCount - threshold;
   const dur = BASE_LOCKOUT_MS * Math.pow(2, exp);
   return Math.min(dur, MAX_LOCKOUT_MS);
 }
@@ -52,13 +59,15 @@ export function checkRateLimit(key, { now = Date.now() } = {}) {
   return { allowed: true };
 }
 
-// Call after a failed login attempt.
-export function recordFailure(key, { now = Date.now() } = {}) {
+// Call after a failed login attempt. `threshold` lets a caller run a second
+// bucket (e.g. account-wide) with a laxer lockout point than the default
+// per-(user,ip) bucket.
+export function recordFailure(key, { now = Date.now(), threshold = FAIL_THRESHOLD } = {}) {
   gcIfDue(now);
   const b = buckets.get(key) || { failCount: 0, lockedUntil: 0, lastSeen: now };
   b.failCount += 1;
   b.lastSeen = now;
-  const dur = lockoutDuration(b.failCount);
+  const dur = lockoutDuration(b.failCount, threshold);
   if (dur > 0) b.lockedUntil = now + dur;
   buckets.set(key, b);
 }

--- a/frontend/server/utils/requestIp.js
+++ b/frontend/server/utils/requestIp.js
@@ -1,0 +1,38 @@
+// Client-IP resolution for security-sensitive throttling.
+//
+// SECURITY: never trust `X-Forwarded-For` blindly. h3's getRequestIP(event,
+// { xForwardedFor: true }) returns the *leftmost* XFF value, which is fully
+// attacker-controlled (the client can send or prepend the header). Keying a
+// rate limiter on that lets a caller mint a fresh bucket per request and
+// bypass lockout entirely.
+//
+// Policy:
+//   - Default (TRUST_PROXY_HOPS unset or 0): use the real transport peer
+//     (socket.remoteAddress). Behind a single reverse proxy this is the
+//     proxy's address — every attacker request then shares one bucket, which
+//     is the safe failure mode (over-throttle, never under-throttle).
+//   - TRUST_PROXY_HOPS=N (operator asserts N trusted proxies sit in front):
+//     take the address the outermost trusted proxy observed, i.e. the N-th
+//     entry counting from the RIGHT of the XFF chain. Everything further left
+//     is client-supplied and untrusted.
+export function getClientIp(event) {
+  const raw = process.env.TRUST_PROXY_HOPS;
+  const hops = raw ? parseInt(raw, 10) : 0;
+
+  if (Number.isFinite(hops) && hops > 0) {
+    const xff = event.node.req.headers['x-forwarded-for'];
+    const chain = (Array.isArray(xff) ? xff.join(',') : xff || '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    // The rightmost entry is the address our immediate (trusted) proxy saw;
+    // counting `hops` in from the right skips the trusted-proxy addresses and
+    // lands on the first client-influenced hop the outermost trusted proxy
+    // recorded. Clamp so a short/forged chain falls back to the leftmost real
+    // entry rather than an out-of-range read.
+    const idx = Math.max(0, chain.length - hops);
+    if (chain[idx]) return chain[idx];
+  }
+
+  return event.node.req.socket?.remoteAddress || 'unknown';
+}

--- a/frontend/server/utils/srtToVtt.js
+++ b/frontend/server/utils/srtToVtt.js
@@ -1,8 +1,14 @@
 import { LRUCache } from 'lru-cache';
 
 // Memoize conversions keyed by source-file path + mtime so a re-edited .srt
-// invalidates automatically. Buffers are small (a few KB each).
-const cache = new LRUCache({ max: 64 });
+// invalidates automatically. Bounded by TOTAL bytes, not entry count: a
+// handful of very large subtitles must not be able to pin gigabytes in memory.
+const MAX_SRT_BYTES = 2 * 1024 * 1024;      // reject subtitles larger than 2 MiB
+const MAX_SRT_CACHE_BYTES = 8 * 1024 * 1024; // total conversion-cache budget
+const cache = new LRUCache({
+  maxSize: MAX_SRT_CACHE_BYTES,
+  sizeCalculation: (buf) => buf.length || 1,
+});
 
 const TIMESTAMP_RE = /^(\d\d:\d\d:\d\d),(\d{3}) --> (\d\d:\d\d:\d\d),(\d{3})$/;
 
@@ -29,6 +35,11 @@ export function srtToVtt(srtBody) {
 // the caller can map it to a 404 / 500.
 export async function convertSrtFileToVtt(srtFilePath, fs) {
   const stat = await fs.promises.stat(srtFilePath);
+  if (stat.size > MAX_SRT_BYTES) {
+    const err = new Error(`SRT file exceeds ${MAX_SRT_BYTES}-byte cap: ${stat.size} bytes`);
+    err.code = 'ESRTTOOLARGE';
+    throw err;
+  }
   const key = `${srtFilePath}:${stat.mtimeMs}`;
   const cached = cache.get(key);
   if (cached) return cached;

--- a/frontend/tests/e2e/auth.spec.js
+++ b/frontend/tests/e2e/auth.spec.js
@@ -20,7 +20,11 @@ test.describe('auth', () => {
     expect(admin, `expected admin "${ADMIN_NAME}" in /api/users response`).toBeTruthy();
     expect(admin.isAdmin).toBe(1);
     expect(admin.is_active).toBe(1);
-    expect(admin.has_password).toBe(1);
+    // The anonymous list no longer bulk-exposes credential-presence flags.
+    // The per-user endpoint (used by the login screen) still reports them.
+    expect('has_password' in admin).toBe(false);
+    const adminDetail = await (await request.get(`/api/users/${admin.id}`)).json();
+    expect(adminDetail.has_password).toBe(1);
     // Sanity: the deleted use_auth column should not surface anywhere.
     expect('use_auth' in admin).toBe(false);
   });

--- a/frontend/tests/e2e/credential-flows.spec.js
+++ b/frontend/tests/e2e/credential-flows.spec.js
@@ -107,8 +107,11 @@ test.describe('Signup — Both option', () => {
     const users = await (await ctx.get('/api/users')).json();
     const created = users.find(u => u.name === name);
     expect(created).toBeTruthy();
-    expect(created.has_password).toBe(1);
-    expect(created.has_pin).toBe(1);
+    // Credential-presence flags come from the per-user endpoint now, not the
+    // anonymous list (which no longer bulk-exposes them).
+    const detail = await (await ctx.get(`/api/users/${created.id}`)).json();
+    expect(detail.has_password).toBe(1);
+    expect(detail.has_pin).toBe(1);
 
     await activate(created.id, name);
 

--- a/frontend/tests/unit/auth-ratelimit-api.test.js
+++ b/frontend/tests/unit/auth-ratelimit-api.test.js
@@ -1,0 +1,66 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createServer } from 'node:http';
+import { createApp, toNodeListener } from 'h3';
+import { v4 as uuidv4 } from 'uuid';
+import { getDb } from '../../server/utils/db.js';
+import { hashCredential } from '../../server/utils/credentials.js';
+import { _resetForTests } from '../../server/utils/rate-limit.js';
+import handler from '../../server/api/users/auth.js';
+
+let server;
+let baseUrl;
+const createdIds = [];
+
+beforeAll(async () => {
+  const app = createApp();
+  app.use(handler);
+  server = createServer(toNodeListener(app));
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+afterAll(async () => {
+  const db = getDb();
+  for (const id of createdIds) db.prepare('DELETE FROM users WHERE id = ?').run(id);
+  await new Promise((resolve) => server.close(resolve));
+});
+
+async function insertPinUser() {
+  const id = uuidv4();
+  createdIds.push(id);
+  const pinHash = await hashCredential('1234');
+  getDb().prepare(`
+    INSERT INTO users (id, name, password, pin, isAdmin, is_active)
+    VALUES (?, ?, NULL, ?, 0, 1)
+  `).run(id, `pinuser-${id}`, pinHash);
+  return id;
+}
+
+// Each attempt carries a DIFFERENT X-Forwarded-For, emulating the finding-#2
+// bypass. With the fix, the derived IP comes from the transport peer (XFF is
+// untrusted by default), so all attempts share one bucket and lock out.
+async function wrongPin(userId, spoofIp) {
+  return fetch(baseUrl, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-forwarded-for': spoofIp },
+    body: JSON.stringify({ userId, pin: '0000' }),
+  });
+}
+
+describe('auth rate limiting is not bypassable via X-Forwarded-For', () => {
+  it('locks out after the threshold despite a fresh spoofed IP per request', async () => {
+    _resetForTests();
+    const userId = await insertPinUser();
+
+    // Five wrong attempts, each with a distinct spoofed forwarded IP.
+    for (let i = 0; i < 5; i++) {
+      const res = await wrongPin(userId, `203.0.113.${i}`);
+      expect(res.status).toBe(200);
+      expect((await res.json()).success).toBe(false);
+    }
+
+    // The sixth is locked out — the rotating header did not create new buckets.
+    const sixth = await wrongPin(userId, '203.0.113.99');
+    expect(sixth.status).toBe(429);
+  });
+});

--- a/frontend/tests/unit/bodyLimit-api.test.js
+++ b/frontend/tests/unit/bodyLimit-api.test.js
@@ -1,0 +1,53 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createServer } from 'node:http';
+import { createApp, toNodeListener, defineEventHandler, readBody } from 'h3';
+import bodyLimit from '../../server/middleware/bodyLimit.js';
+
+let server;
+let baseUrl;
+
+beforeAll(async () => {
+  const app = createApp();
+  app.use(bodyLimit);
+  // Echo handler: proves the body survives the middleware (req.rawBody handoff)
+  // and is still parseable downstream.
+  app.use(defineEventHandler(async (event) => {
+    if (event.node.req.method === 'GET') return { ok: true };
+    const body = await readBody(event);
+    return { got: body };
+  }));
+  server = createServer(toNodeListener(app));
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => server.close(resolve));
+});
+
+describe('body limit middleware', () => {
+  it('passes a normal JSON body through intact', async () => {
+    const res = await fetch(baseUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ hello: 'world', n: 7 }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ got: { hello: 'world', n: 7 } });
+  });
+
+  it('rejects an oversized declared Content-Length with 413', async () => {
+    const big = 'x'.repeat(300 * 1024); // > 256 KiB cap
+    const res = await fetch(baseUrl, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ big }),
+    });
+    expect(res.status).toBe(413);
+  });
+
+  it('leaves GET requests untouched', async () => {
+    const res = await fetch(baseUrl, { method: 'GET' });
+    expect(res.status).toBe(200);
+  });
+});

--- a/frontend/tests/unit/bootstrap-credentials-api.test.js
+++ b/frontend/tests/unit/bootstrap-credentials-api.test.js
@@ -23,13 +23,13 @@ afterAll(async () => {
   await new Promise(resolve => server.close(resolve));
 });
 
-function insertLegacyUser({ active }) {
+function insertLegacyUser({ active, admin = false }) {
   const id = uuidv4();
   createdIds.push(id);
   getDb().prepare(`
     INSERT INTO users (id, name, password, pin, isAdmin, is_active)
-    VALUES (?, ?, NULL, NULL, 0, ?)
-  `).run(id, `legacy-${id}`, active ? 1 : 0);
+    VALUES (?, ?, NULL, NULL, ?, ?)
+  `).run(id, `legacy-${id}`, admin ? 1 : 0, active ? 1 : 0);
   return id;
 }
 
@@ -56,5 +56,15 @@ describe('legacy credential first claim', () => {
   it('refuses an inactive credential-less user', async () => {
     const userId = insertLegacyUser({ active: false });
     expect((await claim(userId)).status).toBe(403);
+  });
+
+  it('refuses to claim a credential-less ADMIN account (no unauth admin takeover)', async () => {
+    const adminId = insertLegacyUser({ active: true, admin: true });
+    const res = await claim(adminId);
+    expect(res.status).toBe(403);
+    // The account must remain credential-less: the claim must not have written.
+    const row = getDb().prepare('SELECT password, pin FROM users WHERE id = ?').get(adminId);
+    expect(row.password).toBeNull();
+    expect(row.pin).toBeNull();
   });
 });

--- a/frontend/tests/unit/requestIp.test.js
+++ b/frontend/tests/unit/requestIp.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { getClientIp } from '../../server/utils/requestIp.js';
+
+function fakeEvent({ xff, remote } = {}) {
+  const headers = {};
+  if (xff !== undefined) headers['x-forwarded-for'] = xff;
+  return { node: { req: { headers, socket: { remoteAddress: remote } } } };
+}
+
+const ORIGINAL = process.env.TRUST_PROXY_HOPS;
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.TRUST_PROXY_HOPS;
+  else process.env.TRUST_PROXY_HOPS = ORIGINAL;
+});
+
+describe('getClientIp', () => {
+  it('ignores X-Forwarded-For by default and uses the transport peer', () => {
+    delete process.env.TRUST_PROXY_HOPS;
+    // Attacker-supplied XFF must NOT be trusted — the real socket wins.
+    const ip = getClientIp(fakeEvent({ xff: '6.6.6.6', remote: '10.0.0.1' }));
+    expect(ip).toBe('10.0.0.1');
+  });
+
+  it('does not let a spoofed leftmost XFF value mint a fresh key', () => {
+    delete process.env.TRUST_PROXY_HOPS;
+    const a = getClientIp(fakeEvent({ xff: 'spoof-a', remote: '10.0.0.1' }));
+    const b = getClientIp(fakeEvent({ xff: 'spoof-b', remote: '10.0.0.1' }));
+    // Rotating XFF cannot change the derived IP → cannot bypass the limiter.
+    expect(a).toBe(b);
+  });
+
+  it('with TRUST_PROXY_HOPS=1 takes the proxy-appended client, not the spoofable leftmost', () => {
+    process.env.TRUST_PROXY_HOPS = '1';
+    // Client sent "1.1.1.1"; the trusted proxy appended the real peer "2.2.2.2".
+    const ip = getClientIp(fakeEvent({ xff: '1.1.1.1, 2.2.2.2', remote: '127.0.0.1' }));
+    expect(ip).toBe('2.2.2.2');
+  });
+
+  it('with a single trusted proxy and one XFF entry returns that entry', () => {
+    process.env.TRUST_PROXY_HOPS = '1';
+    const ip = getClientIp(fakeEvent({ xff: '203.0.113.5', remote: '127.0.0.1' }));
+    expect(ip).toBe('203.0.113.5');
+  });
+
+  it('falls back to the socket when the trusted chain is empty', () => {
+    process.env.TRUST_PROXY_HOPS = '1';
+    const ip = getClientIp(fakeEvent({ remote: '10.0.0.9' }));
+    expect(ip).toBe('10.0.0.9');
+  });
+});

--- a/frontend/tests/unit/users-list-api.test.js
+++ b/frontend/tests/unit/users-list-api.test.js
@@ -1,0 +1,52 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createServer } from 'node:http';
+import { createApp, toNodeListener } from 'h3';
+import { v4 as uuidv4 } from 'uuid';
+import { getDb } from '../../server/utils/db.js';
+import handler from '../../server/api/users/index.js';
+
+let server;
+let baseUrl;
+const createdIds = [];
+
+beforeAll(async () => {
+  const app = createApp();
+  app.use(handler);
+  server = createServer(toNodeListener(app));
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+afterAll(async () => {
+  const db = getDb();
+  for (const id of createdIds) db.prepare('DELETE FROM users WHERE id = ?').run(id);
+  await new Promise((resolve) => server.close(resolve));
+});
+
+function insertUser() {
+  const id = uuidv4();
+  createdIds.push(id);
+  // Has a password + pin so the flags would be 1 if they were exposed.
+  getDb().prepare(`
+    INSERT INTO users (id, name, avatar, password, pin, isAdmin, is_active)
+    VALUES (?, ?, 'x', 'hash', 'hash', 1, 1)
+  `).run(id, `listuser-${id}`);
+  return id;
+}
+
+describe('GET /api/users (unauthenticated list)', () => {
+  it('hides credential-presence flags but keeps isAdmin for the picker', async () => {
+    const id = insertUser();
+    const res = await fetch(baseUrl, { method: 'GET' });
+    expect(res.status).toBe(200);
+    const list = await res.json();
+    const row = list.find((u) => u.id === id);
+    expect(row).toBeTruthy();
+    // Picker needs these:
+    expect(row.name).toContain('listuser-');
+    expect(row.isAdmin).toBe(1);
+    // Recon surface — must NOT be handed to anonymous callers in bulk:
+    expect(row).not.toHaveProperty('has_password');
+    expect(row).not.toHaveProperty('has_pin');
+  });
+});


### PR DESCRIPTION
Implements the validated fix plan from the adversarial security review (two independent review passes agreed on the findings). All server-side; UI-impact was checked before touching anything.

## High
- **Unauth admin takeover via `bootstrap-credentials`** — the endpoint now refuses to claim `isAdmin` accounts (a legacy admin can be credential-less after the auth-hardening upgrade), and the claim is an atomic compare-and-swap so two racing claims can't both win.
- **Rate-limit bypass via `X-Forwarded-For`** — `getClientIp()` no longer trusts the client-supplied leftmost XFF value; it uses the transport peer unless `TRUST_PROXY_HOPS` is set, and adds an account-wide bucket that survives IP rotation. Closes unlimited PIN/password brute-force.
- **Unbounded request bodies** — new global `bodyLimit` middleware caps JSON bodies at 256 KiB (Content-Length + streamed-byte enforcement) before any handler reads them; multipart uploads are left to busboy.

## Medium
- **Registration-disable race** — the gate + auto-approve are re-read inside a synchronous transaction immediately before INSERT.
- **Symlink containment** — reads re-verify the realpath stays inside the course root; `course.json`/`thumbnail.png` writes use a no-follow temp-file + rename (stops the "export overwrites the DB via a planted symlink" vector).
- **Inline active content** — `content/[...path]` serves HTML/JS/SVG/unknown as attachments (SVG keeps its image type so `<img>` still works, but downloads on top-level navigation), preventing same-origin script execution.
- **Legacy rehash race (finding 8)** — the plaintext→argon2 rehash is a compare-and-swap; a concurrent admin reset is no longer clobbered and no post-revocation session is issued.
- **Metadata/subtitle memory** — `course.json` (1 MiB) and `.srt` (2 MiB) reads are size-capped; the SRT cache is byte-bounded.
- **Cookie `Secure`** — new `COOKIE_SECURE` override for TLS proxies that drop `X-Forwarded-Proto`.
- **User-list recon** — `has_password`/`has_pin` are no longer returned to unauthenticated callers on `GET /api/users` (removes the bulk "which accounts have weak/no credentials" map). `isAdmin` stays in the list because the login picker needs it for first-run detection + the admin badge, and the attacks it enabled are already closed; the per-user `[id]` fetch is unchanged. _(Adjusted in a follow-up commit — an earlier version hid `isAdmin` instead, which broke the first-run "Is Admin" checkbox.)_
- **Auth skip-list** — public API routes in the session middleware are now matched exactly instead of by `startsWith`, so a future `/api/logo-*` route can't accidentally inherit the auth-skip.

## New operator env (documented in SECURITY.md)
- `TRUST_PROXY_HOPS` (default `0`) — number of trusted reverse proxies for correct client-IP derivation.
- `COOKIE_SECURE` (default auto) — force the session cookie `Secure` on/off.

## One decision to confirm
The plan's first option was to **remove** the anonymous legacy-account self-claim entirely (admin-only reset). I did **not** remove it — that endpoint is a deliberately-shipped feature and `SECURITY.md` documents the "first visitor claims the account" behavior, so removing it while you were away felt like the wrong unilateral call. Instead I closed the **high-severity** part (admin accounts can never be claimed) and the race. Non-admin credential-less accounts can still be self-claimed on a trusted LAN, as before. If you'd rather rip the endpoint out entirely, that's a small follow-up.

## Verification
- **216 unit tests pass** (was 205; added coverage for the trusted-IP helper, XFF-rotation rate-limit against the real auth handler, the body-limit middleware, admin-claim refusal, and the unauthenticated user-list shape).
- **Production build clean.**
- Playwright/e2e and the Docker suite were **not** run in this environment (same limitation the review noted).
