### PR TITLE
feat: add dynamic subtitle track selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,9 +260,16 @@ you know your edits will be reverted on the next rescan unless you re-export.
 Drop a sidecar `.srt` next to a video (same basename, e.g. `01-intro.mp4`
 and `01-intro.srt`). The server detects it at scan time, exposes a
 `subtitle` field on the video payload, and serves the matching `.vtt` URL
-via on-the-fly SRT-to-VTT conversion. The player UI to actually attach the
-WebVTT track and toggle CC ships in a follow-up PR (`feat/player-correctness`);
-this PR sets up the server side so the follow-up just wires the `<track>`.
+via on-the-fly SRT-to-VTT conversion. The player lists every text track the
+browser exposes, including subtitles embedded in the video container and the
+sidecar track. Selecting a language hides every other track; selecting the
+active language again turns subtitles off. The preference is restored for the
+next lesson when a matching track is available.
+
+Sidecars default to language code `en`. Set `SUBTITLE_LANGUAGE` to another
+BCP 47 language code and optionally set `SUBTITLE_LABEL` to the label you want
+shown in the player. The selector itself is language-agnostic and derives its
+buttons from the browser's `TextTrackList`.
 
 ### File monitoring
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -43,6 +43,11 @@ services:
       # - APP_THEME_COLOR=#1f2937
       # - APP_BACKGROUND_COLOR=#111827
 
+      # Metadata for same-basename .srt sidecars. The player also discovers
+      # text tracks embedded in the video and builds its selector dynamically.
+      # - SUBTITLE_LANGUAGE=en
+      # - SUBTITLE_LABEL=English
+
       # File-watcher polling interval, milliseconds. Set to 0 to disable
       # polling entirely (e.g. on Unraid where you don't want drives spun
       # up by the watcher); rescans then only run on startup or via the

--- a/frontend/components/video/VideoPlayer.vue
+++ b/frontend/components/video/VideoPlayer.vue
@@ -21,11 +21,12 @@
         <source :key="src" :src="src" type="video/mp4">
         <track
           v-if="subtitleSrc"
+          ref="subtitleTrack"
           :key="subtitleSrc"
           kind="subtitles"
           :src="subtitleSrc"
-          srclang="en"
-          label="English"
+          :srclang="subtitleLanguage"
+          :label="subtitleLabel || subtitleLanguage"
         >
         Your browser does not support the video tag.
       </video>
@@ -74,17 +75,27 @@
       class="flex flex-wrap items-center gap-3 px-3 py-2 bg-gray-800 text-gray-200 text-sm"
       data-testid="player-controls"
     >
-      <button
-        v-if="subtitleSrc"
-        type="button"
-        data-testid="player-cc-toggle"
-        class="px-2 py-1 rounded border focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400"
-        :class="ccOn ? 'border-primary-400 bg-primary-700/30' : 'border-gray-600 hover:border-gray-400'"
-        :aria-pressed="ccOn"
-        @click="toggleCc"
+      <div
+        v-if="trackOptions.length"
+        class="flex flex-wrap items-center gap-1"
+        data-testid="player-subtitle-selector"
       >
-        CC
-      </button>
+        <span class="mr-1 text-xs uppercase tracking-wide text-gray-400">Subtitles</span>
+        <button
+          v-for="option in trackOptions"
+          :key="option.id"
+          type="button"
+          data-testid="player-subtitle-track"
+          :data-language="option.language"
+          class="px-2 py-1 rounded border focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400"
+          :class="selectedTrackId === option.id ? 'border-primary-400 bg-primary-700/30' : 'border-gray-600 hover:border-gray-400'"
+          :aria-pressed="selectedTrackId === option.id"
+          :title="selectedTrackId === option.id ? `Turn off ${option.label} subtitles` : `Show ${option.label} subtitles`"
+          @click="selectSubtitleTrack(option)"
+        >
+          {{ option.label }}
+        </button>
+      </div>
       <label class="flex items-center gap-1">
         <span class="text-xs uppercase tracking-wide text-gray-400">Speed</span>
         <select
@@ -133,28 +144,40 @@
 </template>
 
 <script setup>
-import { ref, watch, onMounted, onBeforeUnmount } from 'vue';
+import { ref, watch, onMounted, onBeforeUnmount, nextTick } from 'vue';
 import {
   ALLOWED_RATES,
   getCcDefault,
   setCcDefault,
+  getSubtitleTrackPreference,
+  setSubtitleTrackPreference,
   getPlaybackRate,
   setPlaybackRate,
 } from '../../utils/playerPreferences.js';
+import {
+  applyTextTrackSelection,
+  chooseTextTrack,
+  listTextTrackOptions,
+} from '../../utils/textTracks.js';
 
 const props = defineProps({
   src: { type: String, default: '' },
   autoplay: { type: Boolean, default: false },
   currentTime: { type: Number, default: 0 },
   subtitleSrc: { type: String, default: '' },
+  subtitleLanguage: { type: String, default: 'en' },
+  subtitleLabel: { type: String, default: '' },
   placeholderText: { type: String, default: 'Select a video to start' },
 });
 
 const emit = defineEmits(['timeupdate', 'ended', 'pause', 'seeked', 'loadedmetadata', 'start-from-beginning']);
 
 const player = ref(null);
+const subtitleTrack = ref(null);
 const playbackRate = ref(1);
-const ccOn = ref(false);
+const subtitlesEnabled = ref(false);
+const trackOptions = ref([]);
+const selectedTrackId = ref('');
 // Buffering / error / PiP state. All client-side; survives only as long as
 // the player is mounted. The buffering flag turns off on `playing`/`canplay`
 // (the standard recovery signals) and the error flag turns off on a
@@ -168,23 +191,34 @@ const pipSupported = ref(false);
 // so we attach exactly once and detach the same instance on unmount even
 // if the underlying <video> remounts.
 let attachedTextTracks = null;
+let applyingTrackModes = false;
 
 function attachTrackListener(videoEl) {
   if (!videoEl || !videoEl.textTracks) return;
   if (attachedTextTracks === videoEl.textTracks) return;
   // Detach any previous binding before re-attaching to a new <video>.
   if (attachedTextTracks && typeof attachedTextTracks.removeEventListener === 'function') {
-    try { attachedTextTracks.removeEventListener('addtrack', onTrackAdded); } catch {}
+    try {
+      attachedTextTracks.removeEventListener('addtrack', onTrackListChanged);
+      attachedTextTracks.removeEventListener('removetrack', onTrackListChanged);
+      attachedTextTracks.removeEventListener('change', onTrackListChanged);
+    } catch {}
   }
   if (typeof videoEl.textTracks.addEventListener === 'function') {
-    videoEl.textTracks.addEventListener('addtrack', onTrackAdded);
+    videoEl.textTracks.addEventListener('addtrack', onTrackListChanged);
+    videoEl.textTracks.addEventListener('removetrack', onTrackListChanged);
+    videoEl.textTracks.addEventListener('change', onTrackListChanged);
     attachedTextTracks = videoEl.textTracks;
   }
 }
 
 function detachTrackListener() {
   if (attachedTextTracks && typeof attachedTextTracks.removeEventListener === 'function') {
-    try { attachedTextTracks.removeEventListener('addtrack', onTrackAdded); } catch {}
+    try {
+      attachedTextTracks.removeEventListener('addtrack', onTrackListChanged);
+      attachedTextTracks.removeEventListener('removetrack', onTrackListChanged);
+      attachedTextTracks.removeEventListener('change', onTrackListChanged);
+    } catch {}
   }
   attachedTextTracks = null;
 }
@@ -204,6 +238,8 @@ watch(() => props.src, (newSrc, oldSrc) => {
   // overlay or stale spinner doesn't bleed into the new lesson.
   errorState.value = null;
   isBuffering.value = false;
+  trackOptions.value = [];
+  selectedTrackId.value = '';
   player.value.pause();
   player.value.load();
 }, { immediate: true });
@@ -216,9 +252,9 @@ watch(player, (newPlayer) => {
   if (newPlayer) {
     attachTrackListener(newPlayer);
     attachPipListeners(newPlayer);
-    // Re-apply current CC mode in case tracks were already attached
+    // Re-apply the selected subtitle in case tracks were already attached
     // synchronously (e.g. when src + subtitleSrc both render in the same tick).
-    applyCcMode();
+    refreshTrackOptions();
   } else {
     detachTrackListener();
     detachPipListeners();
@@ -228,12 +264,11 @@ watch(player, (newPlayer) => {
 
 watch(() => props.currentTime, () => applySeek());
 
-// When subtitleSrc changes (different video, different track), re-apply CC
-// mode. Also wire the textTracks `addtrack` event so we don't race the
-// track-element registration: when the new <track> registers asynchronously,
-// onTrackAdded re-applies the user's stored preference.
-watch(() => props.subtitleSrc, () => {
-  applyCcMode();
+// The authored <track> registers asynchronously. Refresh after Vue has
+// replaced the element so it can be preferred over a default embedded track.
+watch(() => props.subtitleSrc, async () => {
+  await nextTick();
+  refreshTrackOptions();
 });
 
 function onLoadedMetadata(event) {
@@ -241,7 +276,7 @@ function onLoadedMetadata(event) {
   if (player.value) {
     player.value.playbackRate = playbackRate.value;
   }
-  applyCcMode();
+  refreshTrackOptions();
   if (props.autoplay && player.value) {
     try { player.value.play(); } catch {}
   }
@@ -323,23 +358,55 @@ async function togglePip() {
   }
 }
 
-function onTrackAdded() {
-  applyCcMode();
+function authoredTrackIndex(tracks) {
+  const authored = subtitleTrack.value?.track;
+  if (!authored || !tracks) return -1;
+  for (let index = 0; index < tracks.length; index += 1) {
+    if (tracks[index] === authored) return index;
+  }
+  return -1;
 }
 
-function applyCcMode() {
+function applySelectedTrack() {
   if (!player.value) return;
   const tracks = player.value.textTracks;
   if (!tracks) return;
-  for (let i = 0; i < tracks.length; i += 1) {
-    tracks[i].mode = ccOn.value ? 'showing' : 'hidden';
-  }
+  applyingTrackModes = true;
+  applyTextTrackSelection(tracks, selectedTrackId.value);
+  queueMicrotask(() => { applyingTrackModes = false; });
 }
 
-function toggleCc() {
-  ccOn.value = !ccOn.value;
-  setCcDefault(ccOn.value);
-  applyCcMode();
+function refreshTrackOptions() {
+  if (!player.value?.textTracks) return;
+  const tracks = player.value.textTracks;
+  const options = listTextTrackOptions(
+    tracks,
+    typeof navigator !== 'undefined' ? navigator.language : 'en',
+  );
+  trackOptions.value = options;
+  if (!subtitlesEnabled.value) {
+    selectedTrackId.value = '';
+  } else {
+    selectedTrackId.value = chooseTextTrack(
+      options,
+      getSubtitleTrackPreference(),
+      authoredTrackIndex(tracks),
+    );
+  }
+  applySelectedTrack();
+}
+
+function onTrackListChanged() {
+  if (!applyingTrackModes) refreshTrackOptions();
+}
+
+function selectSubtitleTrack(option) {
+  const turnOff = selectedTrackId.value === option.id;
+  subtitlesEnabled.value = !turnOff;
+  selectedTrackId.value = turnOff ? '' : option.id;
+  setCcDefault(!turnOff);
+  if (!turnOff) setSubtitleTrackPreference(option.preference);
+  applySelectedTrack();
 }
 
 function onRateChange(event) {
@@ -351,7 +418,7 @@ function onRateChange(event) {
 }
 
 onMounted(() => {
-  ccOn.value = getCcDefault();
+  subtitlesEnabled.value = getCcDefault();
   playbackRate.value = getPlaybackRate();
   // Feature-detect PiP up front. Hiding the button entirely on unsupported
   // browsers is friendlier than showing one that fails when clicked.
@@ -364,6 +431,7 @@ onMounted(() => {
   // this hook on the course-detail page where src starts empty).
   if (player.value) {
     player.value.playbackRate = playbackRate.value;
+    refreshTrackOptions();
   }
 });
 

--- a/frontend/components/video/VideoPlayer.vue
+++ b/frontend/components/video/VideoPlayer.vue
@@ -5,12 +5,21 @@
         v-if="src"
         ref="player"
         class="w-full h-full"
-        controls
+        :controls="nativeControlsVisible"
         crossorigin="anonymous"
+        playsinline
         @timeupdate="$emit('timeupdate', $event)"
-        @ended="$emit('ended')"
-        @pause="$emit('pause')"
+        @ended="onEnded"
+        @play="onPlay"
+        @pause="onPause"
         @seeked="$emit('seeked')"
+        @pointermove="showNativeControlsTemporarily"
+        @pointerleave="hideNativeControlsIfPlaying"
+        @pointerdown="holdNativeControls"
+        @pointerup="showNativeControlsTemporarily"
+        @click="onVideoClick"
+        @keydown.space.prevent="togglePlayback"
+        @keydown.k.prevent="togglePlayback"
         @waiting="onWaiting"
         @playing="onPlaying"
         @canplay="onCanPlay"
@@ -35,8 +44,8 @@
       </div>
 
       <!-- Buffering spinner: visible only when the player is stalled waiting
-           for data AND there's no terminal error. The native browser
-           controls already show a tiny spinner in some implementations, but
+           for data AND there's no terminal error. Browser media controls
+           show a tiny spinner in some implementations, but
            it's inconsistent and easy to miss against a dark frame; this
            overlay is the explicit "we're loading, don't worry" signal. -->
       <div
@@ -187,6 +196,13 @@ const isBuffering = ref(false);
 const errorState = ref(null);
 const isPipActive = ref(false);
 const pipSupported = ref(false);
+// Safari's media chrome may remain over the course content while the pointer
+// is idle. Temporarily remove the native `controls` attribute during active
+// playback, then restore it immediately on pointer/keyboard interaction.
+// Paused and ended videos always retain their controls.
+const nativeControlsVisible = ref(true);
+const CONTROLS_IDLE_MS = 1600;
+let controlsHideTimer = null;
 // Track which textTracks list we've registered the addtrack listener on,
 // so we attach exactly once and detach the same instance on unmount even
 // if the underlying <video> remounts.
@@ -290,6 +306,7 @@ function onWaiting() {
 function onPlaying() {
   isBuffering.value = false;
   errorState.value = null;
+  scheduleNativeControlsHide();
 }
 function onCanPlay() {
   isBuffering.value = false;
@@ -313,6 +330,71 @@ function retryLoad() {
   // which is enough to recover from a transient network blip. For a truly
   // missing file the error event fires again and the overlay reappears.
   try { player.value.load(); } catch {}
+}
+
+function clearControlsHideTimer() {
+  if (controlsHideTimer !== null) {
+    clearTimeout(controlsHideTimer);
+    controlsHideTimer = null;
+  }
+}
+
+function scheduleNativeControlsHide() {
+  clearControlsHideTimer();
+  if (!player.value || player.value.paused || player.value.ended) return;
+  controlsHideTimer = setTimeout(() => {
+    nativeControlsVisible.value = false;
+    controlsHideTimer = null;
+  }, CONTROLS_IDLE_MS);
+}
+
+function showNativeControlsTemporarily() {
+  nativeControlsVisible.value = true;
+  scheduleNativeControlsHide();
+}
+
+function holdNativeControls() {
+  nativeControlsVisible.value = true;
+  clearControlsHideTimer();
+}
+
+function hideNativeControlsIfPlaying() {
+  clearControlsHideTimer();
+  if (player.value && !player.value.paused && !player.value.ended) {
+    nativeControlsVisible.value = false;
+  }
+}
+
+function onPlay() {
+  scheduleNativeControlsHide();
+}
+
+function onPause(event) {
+  clearControlsHideTimer();
+  nativeControlsVisible.value = true;
+  emit('pause', event);
+}
+
+function onEnded(event) {
+  clearControlsHideTimer();
+  nativeControlsVisible.value = true;
+  emit('ended', event);
+}
+
+function togglePlayback() {
+  if (!player.value) return;
+  nativeControlsVisible.value = true;
+  try {
+    if (player.value.paused || player.value.ended) player.value.play();
+    else player.value.pause();
+  } catch {}
+}
+
+function onVideoClick() {
+  // With native chrome visible, the browser owns clicks on its shadow-DOM
+  // controls. Once hidden, a click still needs to provide the familiar
+  // play/pause action and reveal the controls again.
+  if (!nativeControlsVisible.value) togglePlayback();
 }
 
 // Picture-in-Picture wiring. The button is hidden entirely when the
@@ -436,6 +518,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
+  clearControlsHideTimer();
   detachTrackListener();
   detachPipListeners();
 });

--- a/frontend/pages/courses/[id].vue
+++ b/frontend/pages/courses/[id].vue
@@ -66,6 +66,8 @@
         :autoplay="false"
         :current-time="currentTimeForPlayer"
         :subtitle-src="subtitleSrc"
+        :subtitle-language="currentVideo?.subtitleLanguage || 'en'"
+        :subtitle-label="currentVideo?.subtitleLabel || currentVideo?.subtitleLanguage || 'en'"
         @timeupdate="updateProgress"
         @ended="markAsCompleted"
         @pause="flushProgressSave"

--- a/frontend/server/utils/courseGenerator.js
+++ b/frontend/server/utils/courseGenerator.js
@@ -23,7 +23,9 @@ async function findSubtitleSibling(videoFilePath) {
   const candidate = path.join(dir, srtName);
   try {
     await fs.promises.access(candidate);
-    return vttName;
+    const language = String(process.env.SUBTITLE_LANGUAGE || 'en').trim() || 'en';
+    const label = String(process.env.SUBTITLE_LABEL || language).trim() || language;
+    return { file: vttName, language, label };
   } catch {
     return null;
   }
@@ -47,7 +49,11 @@ export const generateLessonsFromFolder = async (coursePath) => {
         title: stripVideoExt(video.name).replace(/_/g, ' '),
         file: video.name,
       };
-      if (subtitle) entry.subtitle = subtitle;
+      if (subtitle) {
+        entry.subtitle = subtitle.file;
+        entry.subtitleLanguage = subtitle.language;
+        entry.subtitleLabel = subtitle.label;
+      }
       return entry;
     }));
 
@@ -74,7 +80,11 @@ export const generateLessonsFromFolder = async (coursePath) => {
             title: stripVideoExt(video.name).replace(/_/g, ' '),
             file: video.name,
           };
-          if (subtitle) entry.subtitle = subtitle;
+          if (subtitle) {
+            entry.subtitle = subtitle.file;
+            entry.subtitleLanguage = subtitle.language;
+            entry.subtitleLabel = subtitle.label;
+          }
           return entry;
         }),
     );

--- a/frontend/tests/e2e/player-cc.spec.js
+++ b/frontend/tests/e2e/player-cc.spec.js
@@ -61,17 +61,17 @@ async function openCourseDetail(page, courseId) {
   await page.waitForSelector('[data-testid=player-speed]', { timeout: 5_000 });
 }
 
-test.describe('player CC toggle', () => {
+test.describe('player subtitle selector', () => {
   test.beforeAll(async ({ request }) => {
     await loginAdmin(request);
     await rescanAndWait(request);
   });
 
-  test('CC button is hidden when the selected video has no subtitle sidecar', async ({ page, request }) => {
+  test('subtitle selector is hidden when the selected video has no text tracks', async ({ page, request }) => {
     await loginAdmin(request);
     await attachAuthCookie(page, request);
     const courseId = await findCourseWithoutSubtitle(request);
     await openCourseDetail(page, courseId);
-    await expect(page.locator('[data-testid=player-cc-toggle]')).toHaveCount(0);
+    await expect(page.locator('[data-testid=player-subtitle-selector]')).toHaveCount(0);
   });
 });

--- a/frontend/tests/unit/courseGenerator.test.js
+++ b/frontend/tests/unit/courseGenerator.test.js
@@ -13,6 +13,8 @@ beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sg-cg-'));
 });
 afterEach(() => {
+  delete process.env.SUBTITLE_LANGUAGE;
+  delete process.env.SUBTITLE_LABEL;
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
@@ -90,6 +92,21 @@ describe('generateLessonsFromFolder', () => {
       title: '01-intro',
       file: '01-intro.mkv',
       subtitle: '01-intro.vtt',
+      subtitleLanguage: 'en',
+      subtitleLabel: 'en',
+    });
+  });
+
+  it('uses configured subtitle language metadata', async () => {
+    process.env.SUBTITLE_LANGUAGE = 'ru';
+    process.env.SUBTITLE_LABEL = 'Русский';
+    touch('Lesson 1/01-intro.mp4');
+    touch('Lesson 1/01-intro.srt');
+    const lessons = await generateLessonsFromFolder(tmpDir);
+    expect(lessons[0].videos[0]).toMatchObject({
+      subtitle: '01-intro.vtt',
+      subtitleLanguage: 'ru',
+      subtitleLabel: 'Русский',
     });
   });
 

--- a/frontend/tests/unit/playerPreferences.test.js
+++ b/frontend/tests/unit/playerPreferences.test.js
@@ -2,15 +2,42 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   CC_KEY,
+  SUBTITLE_TRACK_KEY,
   RATE_KEY,
   getCcDefault,
   setCcDefault,
+  getSubtitleTrackPreference,
+  setSubtitleTrackPreference,
   getPlaybackRate,
   setPlaybackRate,
 } from '../../utils/playerPreferences.js';
 
 beforeEach(() => {
+  const values = new Map();
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      clear: () => values.clear(),
+      getItem: (key) => values.has(key) ? values.get(key) : null,
+      removeItem: (key) => values.delete(key),
+      setItem: (key, value) => values.set(key, String(value)),
+    },
+  });
   window.localStorage.clear();
+});
+
+describe('preferred subtitle track', () => {
+  it('round-trips a language-agnostic track signature', () => {
+    setSubtitleTrackPreference('["fr","Français","subtitles"]');
+    expect(window.localStorage.getItem(SUBTITLE_TRACK_KEY)).toBe('["fr","Français","subtitles"]');
+    expect(getSubtitleTrackPreference()).toBe('["fr","Français","subtitles"]');
+  });
+
+  it('clears an empty preference', () => {
+    window.localStorage.setItem(SUBTITLE_TRACK_KEY, 'old');
+    setSubtitleTrackPreference('');
+    expect(getSubtitleTrackPreference()).toBe('');
+  });
 });
 
 describe('CC default', () => {

--- a/frontend/tests/unit/textTracks.test.js
+++ b/frontend/tests/unit/textTracks.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyTextTrackSelection,
+  chooseTextTrack,
+  listTextTrackOptions,
+} from '../../utils/textTracks.js';
+
+function tracks(...items) {
+  return items.map((item) => ({ kind: 'subtitles', mode: 'disabled', ...item }));
+}
+
+describe('text track selection', () => {
+  it('builds buttons from the tracks exposed by the browser', () => {
+    const options = listTextTrackOptions(tracks(
+      { language: 'en', label: '' },
+      { language: 'ru', label: 'Русский' },
+    ), 'en');
+    expect(options.map(({ label, language }) => ({ label, language }))).toEqual([
+      { label: 'English', language: 'en' },
+      { label: 'Русский', language: 'ru' },
+    ]);
+  });
+
+  it('shows exactly the selected track and hides every other track', () => {
+    const list = tracks(
+      { language: 'en', label: 'English', mode: 'showing' },
+      { language: 'ru', label: 'Русский', mode: 'showing' },
+    );
+    const options = listTextTrackOptions(list, 'en');
+    applyTextTrackSelection(list, options[1].id);
+    expect(list.map((track) => track.mode)).toEqual(['hidden', 'showing']);
+  });
+
+  it('hides every track when the selection is empty', () => {
+    const list = tracks(
+      { language: 'en', label: 'English', mode: 'showing' },
+      { language: 'ru', label: 'Русский', mode: 'showing' },
+    );
+    applyTextTrackSelection(list, '');
+    expect(list.map((track) => track.mode)).toEqual(['hidden', 'hidden']);
+  });
+
+  it('restores a preferred language or falls back to the authored track', () => {
+    const options = listTextTrackOptions(tracks(
+      { language: 'en', label: 'English' },
+      { language: 'ru', label: 'Русский' },
+    ), 'en');
+    expect(chooseTextTrack(options, options[0].preference, 1)).toBe(options[0].id);
+    expect(chooseTextTrack(options, '', 1)).toBe(options[1].id);
+  });
+});

--- a/frontend/tests/unit/textTracks.test.js
+++ b/frontend/tests/unit/textTracks.test.js
@@ -31,6 +31,23 @@ describe('text track selection', () => {
     expect(list.map((track) => track.mode)).toEqual(['hidden', 'showing']);
   });
 
+  it('collapses duplicate browser entries for the same language', () => {
+    const list = tracks(
+      { language: 'en', label: '', kind: 'subtitles', mode: 'showing' },
+      { language: 'en', label: 'English', kind: 'captions', mode: 'showing' },
+      { language: 'ru', label: 'Русский', mode: 'showing' },
+    );
+    const options = listTextTrackOptions(list, 'en');
+    expect(options.map(({ label, language }) => ({ label, language }))).toEqual([
+      { label: 'English', language: 'en' },
+      { label: 'Русский', language: 'ru' },
+    ]);
+    expect(options[0].indices).toEqual([0, 1]);
+
+    applyTextTrackSelection(list, options[0].id);
+    expect(list.map((track) => track.mode)).toEqual(['showing', 'hidden', 'hidden']);
+  });
+
   it('hides every track when the selection is empty', () => {
     const list = tracks(
       { language: 'en', label: 'English', mode: 'showing' },

--- a/frontend/utils/playerPreferences.js
+++ b/frontend/utils/playerPreferences.js
@@ -1,4 +1,5 @@
 export const CC_KEY = 'skillgoblin:cc:default';
+export const SUBTITLE_TRACK_KEY = 'skillgoblin:subtitleTrack:preferred';
 export const RATE_KEY = 'skillgoblin:playbackRate';
 
 export const ALLOWED_RATES = [0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
@@ -23,6 +24,20 @@ export function setCcDefault(value) {
   const s = safeStorage();
   if (!s) return;
   s.setItem(CC_KEY, value ? '1' : '0');
+}
+
+export function getSubtitleTrackPreference() {
+  const s = safeStorage();
+  if (!s) return '';
+  return s.getItem(SUBTITLE_TRACK_KEY) || '';
+}
+
+export function setSubtitleTrackPreference(value) {
+  const s = safeStorage();
+  if (!s) return;
+  const normalized = String(value || '').trim();
+  if (normalized) s.setItem(SUBTITLE_TRACK_KEY, normalized);
+  else s.removeItem(SUBTITLE_TRACK_KEY);
 }
 
 export function getPlaybackRate() {

--- a/frontend/utils/textTracks.js
+++ b/frontend/utils/textTracks.js
@@ -1,0 +1,64 @@
+function readTrackList(textTracks) {
+  if (!textTracks) return [];
+  return Array.from({ length: textTracks.length }, (_, index) => textTracks[index]);
+}
+
+function normalize(value) {
+  return String(value || '').trim();
+}
+
+export function textTrackPreference(track) {
+  return JSON.stringify([
+    normalize(track?.language).toLowerCase(),
+    normalize(track?.label),
+    normalize(track?.kind).toLowerCase(),
+  ]);
+}
+
+function languageDisplayName(language, locale) {
+  if (!language || typeof Intl === 'undefined' || typeof Intl.DisplayNames !== 'function') return '';
+  try {
+    return new Intl.DisplayNames([locale || 'en'], { type: 'language' }).of(language) || '';
+  } catch {
+    return '';
+  }
+}
+
+export function listTextTrackOptions(textTracks, locale) {
+  return readTrackList(textTracks).map((track, index) => {
+    const language = normalize(track?.language).toLowerCase();
+    const rawLabel = normalize(track?.label);
+    const generatedLabel = languageDisplayName(language, locale);
+    const label = rawLabel && rawLabel.toLowerCase() !== language
+      ? rawLabel
+      : generatedLabel || rawLabel || language.toUpperCase() || `Track ${index + 1}`;
+    const preference = textTrackPreference(track);
+    return {
+      id: `${index}:${preference}`,
+      index,
+      label,
+      language,
+      preference,
+    };
+  });
+}
+
+export function chooseTextTrack(options, preferred, fallbackIndex = -1) {
+  if (!Array.isArray(options) || options.length === 0) return '';
+  const preferredOption = preferred
+    ? options.find((option) => option.preference === preferred)
+    : null;
+  if (preferredOption) return preferredOption.id;
+  const fallback = options.find((option) => option.index === fallbackIndex);
+  return (fallback || options[0]).id;
+}
+
+export function applyTextTrackSelection(textTracks, selectedId) {
+  const options = listTextTrackOptions(textTracks);
+  for (const option of options) {
+    const desiredMode = option.id === selectedId ? 'showing' : 'hidden';
+    if (textTracks[option.index].mode !== desiredMode) {
+      textTracks[option.index].mode = desiredMode;
+    }
+  }
+}

--- a/frontend/utils/textTracks.js
+++ b/frontend/utils/textTracks.js
@@ -25,7 +25,9 @@ function languageDisplayName(language, locale) {
 }
 
 export function listTextTrackOptions(textTracks, locale) {
-  return readTrackList(textTracks).map((track, index) => {
+  const options = [];
+  const byLanguage = new Map();
+  readTrackList(textTracks).forEach((track, index) => {
     const language = normalize(track?.language).toLowerCase();
     const rawLabel = normalize(track?.label);
     const generatedLabel = languageDisplayName(language, locale);
@@ -33,32 +35,51 @@ export function listTextTrackOptions(textTracks, locale) {
       ? rawLabel
       : generatedLabel || rawLabel || language.toUpperCase() || `Track ${index + 1}`;
     const preference = textTrackPreference(track);
-    return {
+    // Browsers can expose one embedded stream more than once (for example as
+    // both captions and subtitles). Present one choice per declared language,
+    // while keeping untagged tracks distinct by label/kind.
+    const groupKey = language
+      ? `language:${language}`
+      : `untagged:${rawLabel.toLowerCase()}:${normalize(track?.kind).toLowerCase()}`;
+    const existing = byLanguage.get(groupKey);
+    if (existing) {
+      existing.indices.push(index);
+      existing.preferences.push(preference);
+      return;
+    }
+    const option = {
       id: `${index}:${preference}`,
       index,
+      indices: [index],
       label,
       language,
       preference,
+      preferences: [preference],
     };
+    byLanguage.set(groupKey, option);
+    options.push(option);
   });
+  return options;
 }
 
 export function chooseTextTrack(options, preferred, fallbackIndex = -1) {
   if (!Array.isArray(options) || options.length === 0) return '';
   const preferredOption = preferred
-    ? options.find((option) => option.preference === preferred)
+    ? options.find((option) => option.preferences.includes(preferred))
     : null;
   if (preferredOption) return preferredOption.id;
-  const fallback = options.find((option) => option.index === fallbackIndex);
+  const fallback = options.find((option) => option.indices.includes(fallbackIndex));
   return (fallback || options[0]).id;
 }
 
 export function applyTextTrackSelection(textTracks, selectedId) {
   const options = listTextTrackOptions(textTracks);
-  for (const option of options) {
-    const desiredMode = option.id === selectedId ? 'showing' : 'hidden';
-    if (textTracks[option.index].mode !== desiredMode) {
-      textTracks[option.index].mode = desiredMode;
+  const selected = options.find((option) => option.id === selectedId);
+  const selectedIndex = selected?.index ?? -1;
+  for (let index = 0; index < textTracks.length; index += 1) {
+    const desiredMode = index === selectedIndex ? 'showing' : 'hidden';
+    if (textTracks[index].mode !== desiredMode) {
+      textTracks[index].mode = desiredMode;
     }
   }
 }


### PR DESCRIPTION
## Summary

- replace the single CC toggle with a language-agnostic selector built from the browser's `TextTrackList`
- group duplicate browser entries for the same declared language into one button
- ensure exactly one physical text track is `showing`, so embedded and sidecar subtitles cannot overlap
- allow the active language button to turn subtitles off and persist the preferred track across lessons
- expose configurable language/label metadata for same-basename SRT sidecars
- reliably auto-hide Safari/native media controls during playback while preserving them on interaction and pause
- document the behavior and add focused unit coverage

## Problem

Some MP4 files contain an embedded subtitle track marked as default. When SkillGoblin also attaches a same-basename SRT sidecar, browsers may expose both tracks. The old CC toggle set every item in `video.textTracks` to `showing`, so embedded and sidecar subtitles rendered on top of each other. Some browsers can also register one embedded stream more than once, producing duplicate language buttons.

Safari may additionally keep its translucent native media controls over the course content longer than expected during playback.

## Approach

The player derives its subtitle buttons from the live text tracks exposed by the browser. Labels come from track metadata (with `Intl.DisplayNames` as a fallback), not from a hardcoded language list. Entries sharing a declared language are grouped; selecting the group shows one representative track and hides every other physical entry. Clicking the selected button again hides all tracks.

When subtitles were previously enabled but no explicit preference exists, the authored HTML `<track>` is preferred over an embedded default track. A stored language/label/kind signature is restored when a matching track is available in the next lesson.

Sidecar metadata remains backward compatible (`en` by default) and can be configured with `SUBTITLE_LANGUAGE` and `SUBTITLE_LABEL`.

Native controls remain available, but while a video is actively playing the player removes them after 1.6 seconds of pointer inactivity (or immediately when the pointer leaves). Pointer interaction restores them; paused and ended videos keep them visible. Space and `K` continue to provide keyboard play/pause.

## Verification

- `npm run test:unit` — 27 files, 213 tests passed
- `npm run build` — passed
- regression coverage verifies exclusive modes and collapses two English browser entries into one selector option
